### PR TITLE
docs: fix Next.js version and adapter count inconsistencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,12 +207,12 @@ tawiza/
 │   ├── infrastructure/     # Adapters concrets
 │   │   ├── agents/tajine/  # Agent TAJINE (cœur IA)
 │   │   ├── agents/camel/   # Workforce multi-agents
-│   │   ├── datasources/    # Adaptateurs 18+ APIs
+│   │   ├── datasources/    # Adaptateurs 19 APIs
 │   │   ├── ml/             # Fine-tuning, active learning
 │   │   ├── crawler/        # Crawler adaptatif
 │   │   └── knowledge_graph/# Neo4j client
 │   └── interfaces/api/     # FastAPI routes + WebSocket
-├── frontend/               # Next.js 14
+├── frontend/               # Next.js 15
 │   ├── app/dashboard/      # Pages du dashboard (7)
 │   ├── components/         # Composants React (shadcn/ui)
 │   └── hooks/              # Hooks SWR + custom


### PR DESCRIPTION
Fixed a couple of inconsistencies between `CONTRIBUTING.md` and the main `README.md`:

**Changes:**
- Updated Next.js version from `14` to `15` in the project structure section (line 215) to match the README badge which correctly references Next.js 15
- Updated data source adapter count from `18+` to `19` (line 210) to match the README which lists exactly 19 adapters in the sources table

Small fix but keeps the docs in sync.

Fixes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect Next.js 15 framework version
  * Updated documentation to reflect datasources adapter API level 19

<!-- end of auto-generated comment: release notes by coderabbit.ai -->