### PR TITLE
chore: clean repo artifacts, update roadmap and changelog for 0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,15 @@ credentials/
 *.key
 *.crt
 
+# MLflow / experiment tracking
+mlruns/
+mlartifacts/
+None/
+
+# Tool artifacts (not part of the project)
+configs/system_config.json
+prompts/
+
 # Linting
 .ruff_cache/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Tawiza will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-03-26
+
+### Added
+
+- Sandbox Docker pour scan de sécurité isolé (`Dockerfile.sandbox`, `sandbox-scan.sh`, `pr-scan.sh`)
+- Workflow CI `pr-sandbox.yml` : scan automatique sur chaque Pull Request
+- Workflow CI `security.yml` : CodeQL, Gitleaks, Bandit, Trojan Source, Dependency Review
+- Pre-commit hooks : ruff, bandit, gitleaks, detect-private-key, check-symlinks
+
+### Fixed
+
+- 9 imports cassés dans le backend (alignement tests/code)
+- Build frontend corrigé (ports alignés, configuration cohérente)
+- Accents français manquants dans l'i18n et la documentation
+
+### Changed
+
+- ROADMAP.md restructuré avec liens vers les issues GitHub
+- `.gitignore` étendu pour MLflow et artefacts d'outils
+
 ## [0.1.1] - 2026-03-23
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,29 +2,43 @@
 
 ## Fait
 
-- [x] Reduction du dashboard (19 pages -> 7 pages essentielles)
-- [x] Pipeline de securite CI (CodeQL, Gitleaks, Bandit, Trojan Source)
+- [x] Réduction du dashboard (19 pages → 7 pages essentielles)
+- [x] Pipeline de sécurité CI (CodeQL, Gitleaks, Bandit, Trojan Source)
 - [x] Dependabot + Dependency Review sur les PRs
-- [x] Scan automatique de securite sur chaque PR
+- [x] Scan automatique de sécurité sur chaque PR (sandbox Docker)
+- [x] Pre-commit hooks (ruff, bandit, gitleaks, detect-private-key)
+- [x] Correction des imports cassés et alignement des tests (#54 partiel)
+- [x] Correction des accents français dans l'i18n
+- [x] Alignement des ports et fix du build frontend
 
 ## En cours
 
-- [ ] Stabilisation de l'agent TAJINE (niveaux Causal et Scenario)
-- [ ] Tests end-to-end des adaptateurs de sources
+- [ ] Tests unitaires fonctionnels ([#54](https://github.com/tawiza/tawiza/issues/54))
+- [ ] Tests end-to-end des adaptateurs de sources ([#52](https://github.com/tawiza/tawiza/issues/52))
+- [ ] Stabilisation de l'agent TAJINE (niveaux Causal et Scénario)
 - [ ] Stabilisation du crawler adaptatif
+
+## Prévu — Court terme
+
+- [ ] Guide Docker Compose quick-start ([#66](https://github.com/tawiza/tawiza/issues/66))
+- [ ] Traduction du README en anglais ([#53](https://github.com/tawiza/tawiza/issues/53))
+- [ ] Validation OpenAPI schema en CI ([#67](https://github.com/tawiza/tawiza/issues/67))
+- [ ] Auto-détection Ollama + fallback modèles ([#68](https://github.com/tawiza/tawiza/issues/68))
+- [ ] Accessibilité du dashboard ([#51](https://github.com/tawiza/tawiza/issues/51))
+- [ ] Activation branch protection + CodeRabbit sur GitHub
+
+## Prévu — Moyen terme
+
 - [ ] Finalisation CLI / TUI (fusion v2/v3)
-
-## Prevu
-
 - [ ] Fine-tuning LoRA sur des cas d'usage territoriaux
-- [ ] Investigation bayesienne complete
+- [ ] Investigation bayésienne complète
 - [ ] Extension du Knowledge Graph (Neo4j)
 - [ ] Internationalisation (i18n) du frontend
 - [ ] Mode offline avec cache local des APIs
-- [ ] Plugin system pour les sources de donnees communautaires
 
-## A terme
+## À terme
 
 - Fusion des modules redondants de collecte
 - Simplification de l'architecture des agents
+- Plugin system pour les sources de données communautaires
 - Jupyter Notebook pour l'analyse exploratoire

--- a/scripts/sandbox-scan.sh
+++ b/scripts/sandbox-scan.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────
+# sandbox-scan.sh — Lance le bac a sable de scan securite
+#
+# Usage:
+#   ./scripts/sandbox-scan.sh 42        # Scanne la PR #42
+#   ./scripts/sandbox-scan.sh --branch feat/new-api
+#
+# Le container est :
+#   - Isole du reseau (--network=none)
+#   - Sans volumes montes (clone le repo depuis GitHub)
+#   - Detruit automatiquement apres le scan (--rm)
+#   - En lecture seule sauf /sandbox et /tmp
+# ─────────────────────────────────────────────────
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+IMAGE_NAME="tawiza-sandbox"
+
+# Build l'image si elle n'existe pas ou si --rebuild
+if [[ "${1:-}" == "--rebuild" ]]; then
+    shift
+    docker build -t "$IMAGE_NAME" -f "$PROJECT_DIR/docker/Dockerfile.sandbox" "$PROJECT_DIR"
+elif ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+    echo "Premiere utilisation : construction de l'image sandbox..."
+    docker build -t "$IMAGE_NAME" -f "$PROJECT_DIR/docker/Dockerfile.sandbox" "$PROJECT_DIR"
+fi
+
+# Le container a besoin du reseau pour cloner le repo
+# On le coupe apres le clone via le script interne
+docker run --rm \
+    --name "tawiza-scan-$$" \
+    --memory=512m \
+    --cpus=1 \
+    --read-only \
+    --tmpfs /tmp:size=100m \
+    --tmpfs /sandbox:size=500m \
+    --security-opt=no-new-privileges \
+    --cap-drop=ALL \
+    "$IMAGE_NAME" "$@"


### PR DESCRIPTION
## Summary

- Remove MLflow/tool artifacts (`None/`, `configs/`, `prompts/`) polluting the working directory
- Add `.gitignore` rules to prevent recurrence (MLflow, tool artifacts)
- Restructure `ROADMAP.md`: proper French accents, links to open GitHub issues (#51-#68), new "Court terme" section
- Add `CHANGELOG.md` entry for 0.1.2 covering security pipeline work
- Track `scripts/sandbox-scan.sh` (Docker security sandbox launcher)

## Test plan

- [ ] Verify `.gitignore` rules work (`git status` shows no `None/` or `configs/`)
- [ ] Verify ROADMAP.md issue links resolve correctly
- [ ] Verify CHANGELOG.md formatting renders properly