### PR TITLE
fix(security): correct contact email in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Si vous découvrez une vulnérabilité de sécurité dans Tawiza, **merci de ne 
 
 ### Processus de signalement
 
-1. **Email** : Envoyez un rapport détaillé à **security@tawiza.fr** (ou via le profil GitHub du mainteneur)
+1. **Email** : Envoyez un rapport détaillé à **tawiza.v0@gmail.com**
 2. **Délai** : Nous accusons réception sous 48h
 3. **Correction** : Nous visons un correctif sous 7 jours pour les vulnérabilités critiques
 4. **Disclosure** : Nous coordonnons la divulgation publique avec vous


### PR DESCRIPTION
## Summary

- Fix security contact email: `security@tawiza.fr` → `tawiza.v0@gmail.com`
- The old email doesn't exist — vulnerability reports would have been lost

## Test plan

- [x] Only one file changed, one line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Security vulnerability disclosure contact information has been updated. The new email address is now the primary point of contact for submitting detailed vulnerability reports. All other timelines, procedures, and workflow steps in the security disclosure process remain completely unchanged, providing users with a consistent and reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->