### PR TITLE
feat(ci): add dynamic coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,32 @@ jobs:
             tail -5 pytest-output.txt >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Coverage badge
+        if: github.ref == 'refs/heads/main' && hashFiles('coverage.xml') != ''
+        run: |
+          COV=$(python3 -c "
+          import xml.etree.ElementTree as ET
+          tree = ET.parse('coverage.xml')
+          rate = float(tree.getroot().attrib['line-rate'])
+          print(f'{rate*100:.1f}')
+          ")
+          echo "Coverage: ${COV}%"
+          if (( $(echo "$COV >= 80" | bc -l) )); then COLOR=brightgreen
+          elif (( $(echo "$COV >= 60" | bc -l) )); then COLOR=green
+          elif (( $(echo "$COV >= 40" | bc -l) )); then COLOR=yellowgreen
+          elif (( $(echo "$COV >= 20" | bc -l) )); then COLOR=yellow
+          else COLOR=red; fi
+          echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COV}%\",\"color\":\"${COLOR}\"}" > coverage-badge.json
+          if [ -n "$GIST_TOKEN" ]; then
+            curl -s -X PATCH \
+              -H "Authorization: token $GIST_TOKEN" \
+              -d "{\"files\":{\"tawiza-coverage.json\":{\"content\":$(cat coverage-badge.json | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')}}}" \
+              "https://api.github.com/gists/$GIST_ID" > /dev/null
+          fi
+        env:
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+          GIST_ID: ${{ secrets.COVERAGE_GIST_ID }}
+
   docker:
     name: Docker Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             git add -A
             git commit -m "auto-fix: nettoyage typographique"
-            git push
+            git push || echo "::notice::Push failed (branch protection), skipping auto-fix commit"
           fi
 
   humanize:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 [![Python 3.12+](https://img.shields.io/badge/Python-3.12+-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![Next.js](https://img.shields.io/badge/Next.js-15-000000?style=flat-square&logo=next.js&logoColor=white)](https://nextjs.org/)
 [![CI](https://img.shields.io/github/actions/workflow/status/tawiza/tawiza/ci.yml?style=flat-square&label=CI)](https://github.com/tawiza/tawiza/actions)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/hamidedefr/f740b4f620f275d4cfe294d018e4e944/raw/tawiza-coverage.json&style=flat-square)](https://github.com/tawiza/tawiza/actions)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](https://github.com/tawiza/tawiza/blob/main/CONTRIBUTING.md)
 [![Good First Issues](https://img.shields.io/github/issues/tawiza/tawiza/good%20first%20issue?style=flat-square&label=good%20first%20issues&color=7057ff)](https://github.com/tawiza/tawiza/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 


### PR DESCRIPTION
## Summary
- Add coverage badge to README (shields.io endpoint via gist)
- CI extracts coverage % from `coverage.xml` and updates gist on main pushes
- Badge auto-colors: red (<20%), yellow (<40%), yellowgreen (<60%), green (<80%), brightgreen (>=80%)

## Setup required
- `COVERAGE_GIST_ID` secret: ✅ set
- `GIST_TOKEN` secret: needs PAT with `gist` scope

## Test plan
- [ ] CI passes (lint, tests, security)
- [ ] Badge renders on README after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a live "Coverage" badge to the README that shows current test coverage and links to CI details.

* **Chores**
  * CI now generates a coverage status file and refreshes the hosted badge automatically, using color-coded thresholds to reflect coverage levels.

* **Bug Fixes**
  * Automated fix step no longer fails the workflow if an automatic push is blocked; it emits a notice and continues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->