### PR TITLE
chore(deps): group major updates in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,12 +20,55 @@ updates:
           - "mlflow"
           - "datasets"
           - "accelerate"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       monitoring:
         patterns:
           - "prometheus-*"
           - "opentelemetry-*"
           - "sentry-*"
           - "langfuse"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      python-dev-tools:
+        patterns:
+          - "pytest*"
+          - "ruff"
+          - "black"
+          - "mypy"
+          - "bandit"
+          - "pre-commit"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      python-runtime:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "transformers"
+          - "peft"
+          - "trl"
+          - "mlflow"
+          - "datasets"
+          - "accelerate"
+          - "prometheus-*"
+          - "opentelemetry-*"
+          - "sentry-*"
+          - "langfuse"
+          - "pytest*"
+          - "ruff"
+          - "black"
+          - "mypy"
+          - "bandit"
+          - "pre-commit"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Node.js dependencies (npm)
   - package-ecosystem: "npm"
@@ -44,12 +87,47 @@ updates:
           - "react"
           - "react-dom"
           - "@next/*"
+          - "eslint-config-next"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       ui-components:
         patterns:
           - "@radix-ui/*"
           - "tailwindcss"
           - "class-variance-authority"
           - "lucide-react"
+          - "react-resizable-panels"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      typescript-tooling:
+        patterns:
+          - "typescript"
+          - "@types/*"
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+          - "prettier"
+        exclude-patterns:
+          - "eslint-config-next"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      data-libs:
+        patterns:
+          - "zod"
+          - "apexcharts"
+          - "eventsource-parser"
+          - "date-fns"
+          - "axios"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
 
   # Docker base images
   - package-ecosystem: "docker"
@@ -68,3 +146,11 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Why

The existing Dependabot config groups patch and minor bumps but lets every major update open its own PR. With 9 stale Dependabot PRs in the queue right now (Next 15 → 16, TypeScript 5 → 6, Zod 3 → 4, ESLint 9 → 10, apexcharts 3 → 5, etc.), majors bumps cost a lot of review time and tend to stagnate.

## What

Widens existing groups and adds new ones so every commonly-bumped dep lands in a group, with majors included.

**Python (pip)**
- `ml-dependencies`, `monitoring` (existing): now include major bumps
- `python-dev-tools` (new): pytest*, ruff, black, mypy, bandit, pre-commit
- `python-runtime` (new): catch-all for everything else — **minor + patch only** (runtime majors still open individually, intentional)

**Frontend (npm)**
- `next-ecosystem` (existing): now includes `eslint-config-next` and majors
- `ui-components` (existing): now includes `react-resizable-panels` and majors
- `typescript-tooling` (new): `typescript`, `@types/*`, `eslint`, `eslint-*`, `prettier`
- `data-libs` (new): `zod`, `apexcharts`, `eventsource-parser`, `date-fns`, `axios`

**GitHub Actions**
- `github-actions` (new): catch-all group

## Effect

On the next scheduled run (Monday), the 9 stale PRs would be replaced by approximately 4 grouped PRs. To benefit immediately:

- Either merge the 9 existing PRs now (CI is green on all of them) and let the new config apply to future bumps.
- Or close them, then Dependabot recreates them grouped on Monday.

## Test plan

- [ ] `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` → YAML valid.
- [ ] After merge, watch next Monday's scheduled Dependabot run to confirm groups produce a smaller, sane number of PRs.