### PR TITLE
ci: validate Docker and frontend builds on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,14 +232,52 @@ jobs:
           GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
           GIST_ID: ${{ secrets.COVERAGE_GIST_ID }}
 
-  docker:
-    name: Docker Build
+  frontend-build:
+    name: Frontend Build
     runs-on: ubuntu-latest
-    needs: [test, humanize]
-    if: github.ref == 'refs/heads/main'
+    needs: security
+
+    defaults:
+      run:
+        working-directory: frontend
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        env:
+          NEXT_TELEMETRY_DISABLED: '1'
+        run: npm run build
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    needs: [test, humanize]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Docker image
-        run: docker build -t tawiza:latest .
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: tawiza:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,23 +244,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
+          bun-version: latest
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --no-fund
+        run: bun install --frozen-lockfile
 
       - name: Type check
-        run: npx tsc --noEmit
+        run: bunx tsc --noEmit
 
       - name: Build
         env:
           NEXT_TELEMETRY_DISABLED: '1'
-        run: npm run build
+        run: bun run build
 
   docker:
     name: Docker Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,11 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # Not using --frozen-lockfile: bun.lock occasionally drifts because
+        # Dependabot updates package.json without regenerating bun.lock
+        # (Dependabot manages package-lock.json via npm ecosystem). Letting
+        # bun reconcile on install is the pragmatic compromise.
+        run: bun install
 
       - name: Type check
         run: bunx tsc --noEmit

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tawiza-frontend",
   "version": "1.0.0",
-  "description": "Tawiza — Dashboard d'intelligence territoriale",
+  "description": "Tawiza \u2014 Dashboard d'intelligence territoriale",
   "license": "MIT",
   "homepage": "https://tawiza.fr",
   "repository": {
@@ -106,6 +106,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^20.12.12",
     "@types/react": "^18.3.3",
     "@types/react-dom": "18.3.0",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
 };

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -308,7 +308,11 @@ input:checked.defaultCheckbox::before {
   }
 
   .glass-card {
-    @apply glass;
+    /* Tailwind v4 @apply only works with utility classes, not custom CSS
+       classes like .glass. Inline the .glass properties instead. */
+    background: hsl(var(--card));
+    border-radius: var(--radius-md);
+    box-shadow: var(--card-shadow);
     padding: 1rem;
     transition: box-shadow var(--transition-normal), transform var(--transition-normal);
   }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,6 +1,6 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+@config "../tailwind.config.ts";
+@custom-variant dark (&:is(.dark *));
 
 /* Tawiza Dashboard Theme - Monochrome Zinc + Blue Accent
    Minimalist, ultra-clean design system

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -2,7 +2,7 @@
 import type { Config } from "tailwindcss"
 
 const config = {
-  darkMode: ["class"],
+  darkMode: "class",
   content: [
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',

--- a/frontend/types/styled-jsx.d.ts
+++ b/frontend/types/styled-jsx.d.ts
@@ -1,0 +1,11 @@
+// Type augmentation for styled-jsx (bundled with Next.js but not exposed in
+// the default React types). Adds the `jsx` and `global` boolean attributes
+// on <style> elements so usages like `<style jsx global>{...}</style>` type-check.
+import "react";
+
+declare module "react" {
+  interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
+    jsx?: boolean;
+    global?: boolean;
+  }
+}


### PR DESCRIPTION
## Why

Two gaps in the existing CI configuration made it possible to merge bumps that broke the build:

1. **Docker build was main-only.** `ci.yml` had `if: github.ref == 'refs/heads/main'` on the `docker` job, so every PR — including the 9 Dependabot bumps we recently closed — saw `Docker Build: skipping`.
2. **No frontend build job.** The Next.js frontend was never compiled in CI. `npm run build` (well, `bun run build`) errors only surfaced after merge.

**Spoiler**: enabling these jobs immediately uncovered **5 latent bugs** that were silently breaking the production build.

## What this PR does

### `docker` job
- Remove `if: github.ref == 'refs/heads/main'`.
- Switch from raw `docker build` to `docker/setup-buildx-action@v3` + `docker/build-push-action@v5` with GHA layer caching. After the first run, PR rebuilds take ~20s.
- `push: false` (we only want validation on PRs; `docker-build.yml` still publishes on tags).

### `frontend-build` job (new)
- `needs: security` (parallel with `test`).
- `oven-sh/setup-bun@v2` (the project uses bun, not npm — `bun.lock` is tracked, `package-lock.json` is gitignored).
- `bun install` (without `--frozen-lockfile` — Dependabot still updates `package.json` via the npm ecosystem and bun.lock drifts).
- `bunx tsc --noEmit` (type check).
- `bun run build` (full Next.js production build).

## Bugs uncovered and fixed in this PR

1. **`tailwind.config.ts:5`** — `darkMode: ["class"]` rejected by tailwindcss v4's `DarkModeStrategy` type. Fixed to `darkMode: "class"`.
2. **`components/dashboard/main/FranceMap.tsx:509`** — `<style jsx global>` triggered TS2322 because styled-jsx (bundled with Next.js) does not augment React's `StyleHTMLAttributes`. Added `frontend/types/styled-jsx.d.ts`.
3. **Missing `@tailwindcss/postcss`** — tailwindcss v4 moved the PostCSS plugin out of the main package. `postcss.config.js` was still loading `tailwindcss` directly, throwing at build time. Added the dependency and updated the plugin reference.
4. **`styles/globals.css` used the v3 entrypoint** — `@tailwind base/components/utilities` was replaced by `@import "tailwindcss"` + `@config "../tailwind.config.ts"` (compat shim to keep the existing TS config working) + `@custom-variant dark` for the class-based dark mode.
5. **`@apply glass` no longer works in v4** — `@apply` cannot reuse plain CSS classes, only utilities. Inlined the three properties from `.glass` directly into `.glass-card`.

## Verification

All checks green on this PR (final run):

- Docker Build: pass (19s, GHA cache hit)
- Frontend Build: pass (1m23s, includes `bun install` + `tsc --noEmit` + `next build`)
- Tests: pass (4m47s)
- Analyze (python) + Analyze (javascript-typescript) from CodeQL: pass
- All security checks: pass

## Effect

Future Dependabot bumps — especially the grouped majors arriving next Monday from #130 (`next-ecosystem`, `typescript-tooling`, `ui-components`, `data-libs`) — will be validated end-to-end before merge.

## Notes for review

- The Tailwind v4 migration here is **minimal**, just enough to build. The longer-term cleanup (move theme tokens from `tailwind.config.ts` to `@theme` directives, possibly drop the TS config entirely, convert `.glass`/`.glass-card` to a `@utility`) is its own PR.
- Dependabot still bumps via the npm ecosystem (it touches `package.json` and a phantom `package-lock.json`). The CI now uses bun, so this drift is annoying but tolerable until we switch Dependabot to a bun-aware updater.