### PR TITLE
docs: announce transition to non-profit + co-founder call

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -61,6 +61,16 @@ Tawiza collecte des données depuis les APIs gouvernementales françaises et les
 
 ---
 
+## Appel à co-fondation
+
+Tawiza est en cours de constitution en association loi 1901. Je cherche deux ou trois co-fondateur·rices pour partager la gouvernance et les signatures - pas pour écrire du code, pas pour faire du growth.
+
+Si lire des données publiques mal publiées vous démange autant que moi, l'appel est ici : [tawiza.fr/association](https://tawiza.fr/association).
+
+Spoiler : non rémunéré. Le financement suit la structure, pas l'inverse.
+
+---
+
 ## Sources de données
 
 19 adaptateurs codés. Les sources sans auth sont utilisables directement, les autres nécessitent des clés API gratuites.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Tawiza collects data from French government APIs and organizes it to analyze ter
 
 ---
 
+## Co-founders wanted
+
+Tawiza is being transitioned to a French non-profit (*association loi 1901*). I'm looking for two or three co-founders to share governance and signatures - not to write code, not to do growth.
+
+If reading badly-published open data gives you the same itch as me, the call is here: [tawiza.fr/association](https://tawiza.fr/association).
+
+Spoiler: unpaid. Funding follows the structure, not the other way around.
+
+---
+
 ## Data Sources
 
 19 coded adapters. Sources without auth can be used directly, others require free API keys.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,7 @@
 
 ## En cours
 
+- [ ] Constitution en association loi 1901 — appel à co-fondateur·rices en cours ([tawiza.fr/association](https://tawiza.fr/association))
 - [ ] Tests unitaires fonctionnels ([#54](https://github.com/tawiza/tawiza/issues/54))
 - [ ] Tests end-to-end des adaptateurs de sources ([#52](https://github.com/tawiza/tawiza/issues/52))
 - [ ] Stabilisation de l'agent TAJINE (niveaux Causal et Scénario)


### PR DESCRIPTION
## Summary

Tawiza is being transitioned from a solo open-source project to a French non-profit (*association loi 1901*), with an open call for two or three co-founders. This PR adds the announcement to the docs and points to the future landing page.

## Changes

- **README.md**: new section *"Co-founders wanted"* between *Project status* and *Data Sources*. Three short paragraphs: the transition, the call (governance — not code, not growth), the honest disclaimer (unpaid).
- **README.fr.md**: same section in French (*"Appel à co-fondation"*).
- **ROADMAP.md**: add *"Constitution en association loi 1901"* as an *En cours* item, with the same link.

All three link to [`tawiza.fr/association`](https://tawiza.fr/association).

## Notes

- The landing page itself is **not** in this repo. It will live in `tawiza-website` (or be served as a static page from `tawiza.fr`). The link is currently a forward declaration — once the page is published, no doc change is needed here.
- The tone deliberately matches the existing README voice (sober, anti-jargon, slightly self-deprecating). The longer, snappier version of this message lives in the `articles/asso-call/` drafts (not yet committed).
- No code change.

## Test plan

- [x] Both README sections render cleanly in GitHub markdown preview.
- [x] Link target `https://tawiza.fr/association` is consistent across the three files.
- [ ] Once `tawiza-website` ships the actual page, verify the link resolves.