### PR TITLE
docs(readme): recommend running in an isolated environment

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -122,6 +122,16 @@ L'agent TAJINE suit le cycle PPDSL (Perceive-Plan-Delegate-Synthesize-Learn) ave
 
 ## Quick Start
 
+> [!IMPORTANT]
+> **Toujours exécuter Tawiza dans un environnement isolé.** Le projet tire une grosse arborescence de dépendances (FastAPI, SQLAlchemy, clients Ollama, Playwright, ~470 packages transitifs) et un ensemble de services (PostgreSQL, Redis, éventuellement Neo4j). Les installer en global sur la machine hôte est une mauvaise idée pour la reproductibilité comme pour la sécurité.
+>
+> Choisir l'une des options :
+> - **Docker Compose** (recommandé pour un run complet) : `docker compose up -d` — chaque service tourne dans son conteneur, l'hôte n'est pas touché.
+> - **Virtualenv Python** (pour le dev backend en local) : `python -m venv .venv && source .venv/bin/activate` avant `pip install`. Jamais de `sudo pip install` ni d'installation au niveau user/système.
+> - **VM dédiée / dev container / nix-shell** pour isoler aussi l'hôte.
+>
+> Si vous voulez seulement tester l'API ou le dashboard, la voie *Avec Docker Compose* ci-dessous est la plus sûre.
+
 ### Prérequis
 
 - Python 3.12+

--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ The TAJINE agent follows the PPDSL cycle (Perceive-Plan-Delegate-Synthesize-Lear
 
 ## Quick Start
 
+> [!IMPORTANT]
+> **Always run Tawiza in an isolated environment.** The project pulls in a large dependency tree (FastAPI, SQLAlchemy, Ollama clients, Playwright, ~470 transitive packages) and a stack of services (PostgreSQL, Redis, optionally Neo4j). Installing those globally on your host is a bad idea for both reproducibility and security.
+>
+> Pick one of:
+> - **Docker Compose** (recommended for a full run): `docker compose up -d` — every service runs in its own container, your host stays untouched.
+> - **Python virtualenv** (for local backend dev): `python -m venv .venv && source .venv/bin/activate` before `pip install`. Never `sudo pip install` or install at the user/system level.
+> - **A dedicated VM / dev container / nix-shell** if you want full isolation for the host too.
+>
+> If you only want to test the API or the dashboard, the *With Docker Compose* path below is the safest.
+
 ### Prerequisites
 
 - Python 3.12+


### PR DESCRIPTION
## Why

The Quick Start section already shows the right commands (`python -m venv`, `docker compose up`), but it doesn't say **why** those commands matter. New contributors who skim might `pip install -e .` on their global Python, then complain when the ~470 transitive packages break their other projects.

## What

Add a `> [!IMPORTANT]` admonition right above *Prerequisites*, in both `README.md` and `README.fr.md`. The note explains:
- The reason (large dependency tree + a stack of services).
- Three isolation choices, ranked: Docker Compose (full run), virtualenv (local backend dev), or a dedicated VM / dev container.
- Explicit warning against `sudo pip install` and global / user-level installs.

The existing install commands stay unchanged.

## Test plan

- [x] Both files render the `> [!IMPORTANT]` GitHub admonition correctly in markdown preview.
- [x] Wording stays in the existing sober / anti-jargon voice.