### PR TITLE
fix(frontend): drop invalid pseudo-element selector breaking Tailwind v4 build

### DIFF
--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -205,10 +205,6 @@ input.defaultCheckbox::before {
   transform: translate(-50%, 0px);
 }
 
-input.defaultCheckbox::before path {
-  fill: currentColor;
-}
-
 input:checked.defaultCheckbox::before {
   opacity: 1;
 }


### PR DESCRIPTION
## Summary

The selector `input.defaultCheckbox::before path` in `frontend/styles/globals.css` targeted a `path` element inside a pseudo-element whose content is an inline SVG data URL. SVG elements inside `content: url(data:...)` are not styleable from external CSS, so the rule had no visual effect under Tailwind v3 either.

Tailwind v4's PostCSS parser is stricter and rejects this selector pattern with `Pseudo-elements like '::before' or '::after' can't be followed by selectors like 'Ident("path")'`, breaking the local frontend build.

## Changes

- Remove the 3 dead lines (lines 208-210 of the original file). No behavior change.

## Verification

- `npm run dev` builds without the PostCSS parse error.
- `/login` page renders correctly (verified with Playwright screenshot).

## Notes

This is a small step toward closing #149 (Complete Tailwind v3 to v4 migration). The rest of the migration scope is still open.

Refs #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified checkbox element styling by removing unnecessary CSS rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tawiza/tawiza/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->