### PR TITLE
fix(alembic): split CREATE TABLE+INDEX for asyncpg compatibility

### DIFF
--- a/alembic/versions/20260223_0200_add_relation_snapshots.py
+++ b/alembic/versions/20260223_0200_add_relation_snapshots.py
@@ -20,9 +20,6 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Create the relation_snapshots table for timeline tracking."""
-    # CREATE TABLE cannot use IF NOT EXISTS inside an Alembic transaction
-    # when combined with index creation, so we handle it cleanly.
-    op.execute("COMMIT")
     op.execute("""
         CREATE TABLE IF NOT EXISTS relation_snapshots (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -38,11 +35,12 @@ def upgrade() -> None:
             density FLOAT NOT NULL DEFAULT 0.0,
             communities_count INT NOT NULL DEFAULT 0,
             metrics_json JSONB DEFAULT '{}'
-        );
-        CREATE INDEX IF NOT EXISTS idx_snapshots_dept_time
-            ON relation_snapshots(department_code, snapshot_at DESC);
+        )
     """)
-    op.execute("BEGIN")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_snapshots_dept_time "
+        "ON relation_snapshots(department_code, snapshot_at DESC)"
+    )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary

`alembic upgrade head` fails on a fresh local install with:

```
asyncpg.exceptions.PostgresSyntaxError: cannot insert multiple commands into a prepared statement
[SQL: CREATE TABLE IF NOT EXISTS relation_snapshots (...); CREATE INDEX IF NOT EXISTS idx_snapshots_dept_time ON relation_snapshots(...)]
```

The asyncpg driver prepares each `op.execute()` call as a single statement and rejects scripts containing multiple SQL commands. The migration combined the `CREATE TABLE` and `CREATE INDEX` in one `op.execute()` block, so it broke for everyone using the async engine declared in `alembic/env.py`.

## Fix

- Split the table creation and the index creation into two separate `op.execute()` calls.
- Drop the manual `COMMIT`/`BEGIN` framing. With one statement per execute, the default transactional DDL handles it correctly.

## Resulting schema

Identical. The migration just goes through asyncpg without errors now.

## Verification

Ran `alembic upgrade head` end to end against a fresh local Postgres + asyncpg driver: all migrations through to `e4f5a6b7c8d9 (head)` apply cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Enhanced data storage with indexed relation snapshots to support improved tracking and retrieval of historical department information with better query performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tawiza/tawiza/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->