### PR TITLE
fix(config): use JSON array format for CORS_ORIGINS in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,8 @@ LOG_LEVEL=INFO
 API_HOST=0.0.0.0
 API_PORT=8000
 API_PREFIX=/api/v1
-CORS_ORIGINS=http://localhost:3000,http://localhost:8000
+# Pydantic Settings parses list[str] from a JSON-encoded value, not CSV.
+CORS_ORIGINS=["http://localhost:3000","http://localhost:8000"]
 
 # Database
 # SECURITY: Change default password in production


### PR DESCRIPTION
## Summary

Copying `.env.example` to `.env` produces a backend startup failure:

```
pydantic_settings.exceptions.SettingsError: error parsing value for field "cors_origins" from source "EnvSettingsSource"
```

Pydantic Settings parses `list[str]` from a **JSON-encoded value**, not a comma-separated string. The current example uses CSV, which is silently incompatible.

## Fix

Switch the example to the JSON array notation that Pydantic accepts, plus a short comment so future readers know why:

```diff
-CORS_ORIGINS=http://localhost:3000,http://localhost:8000
+# Pydantic Settings parses list[str] from a JSON-encoded value, not CSV.
+CORS_ORIGINS=["http://localhost:3000","http://localhost:8000"]
```

## Verification

Reproduced the error locally with the CSV form. With the JSON form, the backend boots and `alembic upgrade head` runs to completion against a fresh `tawiza` postgres role/db.