### PR TITLE
fix(frontend): replace broken /dashboard/web-intel redirects with placeholder pages

### DIFF
--- a/frontend/app/dashboard/data-sources/page.tsx
+++ b/frontend/app/dashboard/data-sources/page.tsx
@@ -1,2 +1,31 @@
-import { redirect } from "next/navigation"
-export default function Page() { redirect("/dashboard/web-intel?tab=sources") }
+import Link from "next/link";
+
+export default function DataSourcesPage() {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-8">
+      <div className="max-w-xl space-y-4 text-center">
+        <h1 className="text-2xl font-semibold">Sources de données</h1>
+        <p className="text-muted-foreground">
+          La vue détaillée des sources n&apos;est pas encore disponible dans
+          cette version. En attendant, un récapitulatif des sources actives
+          est affiché sur le tableau de bord principal, et l&apos;API REST
+          expose la liste complète.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
+          <Link
+            href="/dashboard/main"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            Voir le tableau de bord
+          </Link>
+          <Link
+            href="/api/v1/sources/"
+            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+          >
+            API: GET /api/v1/sources/
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/settings/crawler/page.tsx
+++ b/frontend/app/dashboard/settings/crawler/page.tsx
@@ -1,2 +1,31 @@
-import { redirect } from "next/navigation"
-export default function Page() { redirect("/dashboard/web-intel?tab=config") }
+import Link from "next/link";
+
+export default function CrawlerSettingsPage() {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-8">
+      <div className="max-w-xl space-y-4 text-center">
+        <h1 className="text-2xl font-semibold">Configuration du crawler</h1>
+        <p className="text-muted-foreground">
+          L&apos;interface de configuration du crawler n&apos;est pas encore
+          disponible dans cette version. La configuration courante est lue
+          via les variables d&apos;environnement et exposée en lecture seule
+          par l&apos;API REST.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
+          <Link
+            href="/dashboard/settings"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            Retour aux paramètres
+          </Link>
+          <Link
+            href="/api/v1/sources/feeds/config"
+            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+          >
+            API: GET /api/v1/sources/feeds/config
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Two sidebar entries (Sources, Configuration crawler) led to a 404. The pages were stubs that redirected to `/dashboard/web-intel?tab=...`, but that route does not exist in this repo (the real `web-intel` page lives outside the public baseline). Self-hosters clicking either entry hit a dead end.

## Affected files

- `frontend/app/dashboard/data-sources/page.tsx`
- `frontend/app/dashboard/settings/crawler/page.tsx`

Both were 2-line files containing only `redirect("/dashboard/web-intel?tab=...")`.

## Fix

Replace each redirect with a minimal honest placeholder that:
- Tells the visitor the detailed UI is not available yet
- Points to a working alternative (the dashboard for source overview, the settings page for crawler config)
- Surfaces the REST endpoint that already exposes the same data (`/api/v1/sources/` and `/api/v1/sources/feeds/config`)

No new feature, no client-side state, no fetch — just a clean centred message + two action buttons.

## Verification

`npm run build` succeeds. Manually clicked both sidebar entries in a local dev run: the placeholder pages render correctly in both light and dark mode and the action buttons go to working routes.