### PR TITLE
fix(frontend): add placeholder pages for 4 broken dashboard routes

### DIFF
--- a/frontend/app/dashboard/fine-tuning/page.tsx
+++ b/frontend/app/dashboard/fine-tuning/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export default function FineTuningPage() {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-8">
+      <div className="max-w-xl space-y-4 text-center">
+        <h1 className="text-2xl font-semibold">Fine-tuning</h1>
+        <p className="text-muted-foreground">
+          L&apos;interface de fine-tuning n&apos;est pas encore disponible
+          dans cette version. L&apos;entrainement et l&apos;amélioration du
+          modèle se font via les scripts <code>src/</code> et MLflow, en
+          dehors du tableau de bord.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
+          <Link
+            href="/dashboard/settings"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            Retour aux paramètres
+          </Link>
+          <Link
+            href="https://github.com/tawiza/tawiza/blob/main/docs/modules/llm.md"
+            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+          >
+            Documentation LLM
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/intelligence/page.tsx
+++ b/frontend/app/dashboard/intelligence/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export default function IntelligencePage() {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-8">
+      <div className="max-w-xl space-y-4 text-center">
+        <h1 className="text-2xl font-semibold">Intelligence territoriale</h1>
+        <p className="text-muted-foreground">
+          La vue dédiée à l&apos;intelligence territoriale n&apos;est pas
+          encore disponible. Une synthèse est affichée sur le tableau de
+          bord principal, et les analyses détaillées passent par
+          l&apos;agent TAJINE.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
+          <Link
+            href="/dashboard/main"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            Voir le tableau de bord
+          </Link>
+          <Link
+            href="/dashboard/tajine"
+            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+          >
+            Ouvrir TAJINE
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/investigation/page.tsx
+++ b/frontend/app/dashboard/investigation/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+export default function InvestigationPage() {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-8">
+      <div className="max-w-xl space-y-4 text-center">
+        <h1 className="text-2xl font-semibold">Investigation</h1>
+        <p className="text-muted-foreground">
+          L&apos;interface d&apos;investigation territoriale n&apos;est pas
+          encore disponible dans cette version. Les analyses peuvent être
+          lancées depuis l&apos;agent TAJINE ou via l&apos;API REST.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
+          <Link
+            href="/dashboard/tajine"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            Ouvrir TAJINE
+          </Link>
+          <Link
+            href="/api/v1/tajine/conversations"
+            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+          >
+            API: GET /api/v1/tajine/conversations
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/signals/page.tsx
+++ b/frontend/app/dashboard/signals/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export default function SignalsPage() {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-8">
+      <div className="max-w-xl space-y-4 text-center">
+        <h1 className="text-2xl font-semibold">Signaux territoriaux</h1>
+        <p className="text-muted-foreground">
+          La vue détaillée des signaux territoriaux n&apos;est pas encore
+          disponible. Les signaux par département sont accessibles via
+          l&apos;API REST, et un récapitulatif est visible sur la fiche du
+          département concerné.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3 pt-2">
+          <Link
+            href="/dashboard/departments"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            Voir les départements
+          </Link>
+          <Link
+            href="/api/v1/signals/list"
+            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
+          >
+            API: GET /api/v1/signals/list
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Admin navbar and mobile bottom nav advertise four routes (`/dashboard/fine-tuning`, `/dashboard/investigation`, `/dashboard/intelligence`, `/dashboard/signals`) but the corresponding folders never existed in `app/dashboard/`, so each click landed on a hard 404.
- Add minimal placeholder pages following the same pattern already used for `data-sources` and `settings/crawler` (introduced in #184), explaining that the dedicated UI is not available yet and linking to the existing REST endpoints when one applies.
- The pages point to the real endpoints (`GET /api/v1/signals/list`, `GET /api/v1/tajine/conversations`) rather than to fictional URLs.

## Test plan

- [x] `npm run build` succeeds (Turbopack) and lists the four new routes in the route table.
- [ ] Manual: open `/dashboard/fine-tuning`, `/dashboard/investigation`, `/dashboard/intelligence`, `/dashboard/signals` and confirm each renders the placeholder instead of 404.