### PR TITLE
fix(config): document required docker-compose env vars (DATABASE/REDIS/GRAFANA_PASSWORD)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,11 +13,17 @@ CORS_ORIGINS=["http://localhost:3000","http://localhost:8000"]
 
 # Database
 # SECURITY: Change default password in production
+# DATABASE_PASSWORD is required by docker-compose.yml (POSTGRES_PASSWORD)
+# and must match the password embedded in DATABASE_URL below.
+DATABASE_PASSWORD=CHANGE_ME_IN_PRODUCTION
 DATABASE_URL=postgresql+asyncpg://tawiza:CHANGE_ME_IN_PRODUCTION@localhost:5432/tawiza
 DATABASE_POOL_SIZE=10
 DATABASE_MAX_OVERFLOW=20
 
 # Redis (for caching and message queue)
+# REDIS_PASSWORD is required by docker-compose.yml. If you change it,
+# update REDIS_URL accordingly (redis://:PASSWORD@localhost:6379/0).
+REDIS_PASSWORD=CHANGE_ME_IN_PRODUCTION
 REDIS_URL=redis://localhost:6379/0
 
 # MLflow
@@ -143,6 +149,10 @@ RETRAINING_ACCURACY_THRESHOLD=0.85
 # Monitoring
 PROMETHEUS_PORT=9090
 GRAFANA_PORT=3003  # Port 3003: evite conflit avec Next.js (3000)
+# GRAFANA_PASSWORD is required by docker-compose.yml (admin user password).
+# GRAFANA_USER is optional and defaults to "admin".
+GRAFANA_USER=admin
+GRAFANA_PASSWORD=CHANGE_ME_IN_PRODUCTION
 EVIDENTLY_PORT=8080
 
 # Deployment


### PR DESCRIPTION
## Summary

- The README's Docker quickstart says \`cp .env.example .env && docker compose up -d\`, but the compose file requires three variables with no default (\`DATABASE_PASSWORD\`, \`REDIS_PASSWORD\`, \`GRAFANA_PASSWORD\`) that \`.env.example\` did not document.
- Running the quickstart as written previously failed with \`required variable DATABASE_PASSWORD is missing a value\`.
- Add the three required variables with \`CHANGE_ME_IN_PRODUCTION\` placeholders, plus optional \`GRAFANA_USER\`, with comments explaining their relationship to existing entries (\`DATABASE_URL\`, \`REDIS_URL\`).

## Test plan

- [x] \`docker compose --env-file <copy of .env.example> config\` now resolves all interpolations without error.
- [ ] \`cp .env.example .env && docker compose up -d postgres redis\` brings both containers up healthy.