### PR TITLE
fix(mcp): resolve broken imports in prospection and benchmark tools

### DIFF
--- a/src/infrastructure/mcp/tools/benchmark.py
+++ b/src/infrastructure/mcp/tools/benchmark.py
@@ -94,30 +94,6 @@ BENCHMARK_TESTS = {
         "expected_min_results": 20,
         "timeout": 60,
     },
-    "geocoding": {
-        "name": "Géocodage BAN",
-        "description": "Test de géocodage d'adresses",
-        "tool": "geocode_address",
-        "params": {"address": "1 rue de la République, Lille"},
-        "expected_min_results": 1,
-        "timeout": 15,
-    },
-    "news_search": {
-        "name": "Recherche actualités",
-        "description": "Test de recherche d'actualités économiques",
-        "tool": "news_search",
-        "params": {"query": "startup levée de fonds", "limit": 10},
-        "expected_min_results": 3,
-        "timeout": 30,
-    },
-    "bodacc_search": {
-        "name": "Recherche BODACC",
-        "description": "Test de recherche dans les annonces légales",
-        "tool": "bodacc_search",
-        "params": {"query": "création entreprise Lille"},
-        "expected_min_results": 1,
-        "timeout": 30,
-    },
     "market_analysis": {
         "name": "Analyse de marché complète",
         "description": "Test de l'analyse multi-sources",
@@ -161,8 +137,8 @@ def register_benchmark_tools(mcp: FastMCP) -> None:
 
         Args:
             tests: Liste des tests à exécuter. Si vide, exécute tous les tests.
-                   Tests disponibles: sirene_basic, sirene_advanced, geocoding,
-                   news_search, bodacc_search, market_analysis, comparison, prospect
+                   Tests disponibles: sirene_basic, sirene_advanced,
+                   market_analysis, comparison, prospect
             quick_mode: Si True, exécute seulement les tests rapides (< 60s)
 
         Returns:
@@ -210,9 +186,6 @@ def register_benchmark_tools(mcp: FastMCP) -> None:
         # Import tools for testing
         try:
             from src.infrastructure.agents.camel.tools.territorial_tools import (
-                bodacc_search,
-                geocode_address,
-                news_search,
                 sirene_search,
             )
         except ImportError as e:
@@ -228,9 +201,6 @@ def register_benchmark_tools(mcp: FastMCP) -> None:
         # Map tool names to functions
         tool_functions = {
             "sirene_search": sirene_search,
-            "geocode_address": geocode_address,
-            "news_search": news_search,
-            "bodacc_search": bodacc_search,
         }
 
         # Run tests
@@ -408,7 +378,7 @@ def register_benchmark_tools(mcp: FastMCP) -> None:
         Mesure la performance moyenne et la stabilité d'un outil.
 
         Args:
-            tool_name: Nom de l'outil à tester (sirene_search, geocode_address, etc.)
+            tool_name: Nom de l'outil à tester (sirene_search)
             iterations: Nombre d'itérations (1-10)
 
         Returns:
@@ -422,9 +392,6 @@ def register_benchmark_tools(mcp: FastMCP) -> None:
         # Import tools
         try:
             from src.infrastructure.agents.camel.tools.territorial_tools import (
-                bodacc_search,
-                geocode_address,
-                news_search,
                 sirene_search,
             )
         except ImportError as e:
@@ -441,18 +408,6 @@ def register_benchmark_tools(mcp: FastMCP) -> None:
             "sirene_search": {
                 "func": sirene_search,
                 "params": {"query": "tech Lille", "limite": 20},
-            },
-            "geocode_address": {
-                "func": geocode_address,
-                "params": {"address": "1 rue de la République, Lille"},
-            },
-            "news_search": {
-                "func": news_search,
-                "params": {"query": "startup tech", "limit": 10},
-            },
-            "bodacc_search": {
-                "func": bodacc_search,
-                "params": {"query": "création Lille"},
             },
         }
 

--- a/src/infrastructure/mcp/tools/web_search.py
+++ b/src/infrastructure/mcp/tools/web_search.py
@@ -9,6 +9,68 @@ from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 
 
+async def web_search_impl(
+    query: str,
+    max_results: int = 10,
+    region: str = "fr-fr",
+    search_type: str = "auto",
+) -> list[dict]:
+    """Run a DuckDuckGo web search and return a list of result dicts.
+
+    Module-level helper reused by both the MCP `web_search` tool and other
+    callers (e.g. lead enrichment in `prospection.py`).
+    """
+    import warnings
+
+    from duckduckgo_search import DDGS
+
+    warnings.filterwarnings("ignore")
+
+    results: list[dict] = []
+    ddgs = DDGS()
+
+    if search_type in ("text", "auto"):
+        try:
+            for r in ddgs.text(query, region=region, max_results=max_results):
+                url = r.get("href", "")
+                if ".cn" not in url and "baidu" not in url:
+                    results.append(
+                        {
+                            "title": r.get("title", ""),
+                            "url": url,
+                            "description": r.get("body", ""),
+                            "type": "web",
+                        }
+                    )
+        except Exception as e:
+            logger.debug(f"Text search failed: {e}")
+
+    if (search_type == "auto" and len(results) < 3) or search_type == "news":
+        try:
+            for r in ddgs.news(query, region=region, max_results=max_results):
+                results.append(
+                    {
+                        "title": r.get("title", ""),
+                        "url": r.get("url", ""),
+                        "description": r.get("body", ""),
+                        "source": r.get("source", ""),
+                        "date": r.get("date", ""),
+                        "type": "news",
+                    }
+                )
+        except Exception as e:
+            logger.debug(f"News search failed: {e}")
+
+    seen_urls: set[str] = set()
+    unique_results: list[dict] = []
+    for r in results:
+        if r["url"] not in seen_urls:
+            seen_urls.add(r["url"])
+            unique_results.append(r)
+
+    return unique_results[:max_results]
+
+
 def register_web_search_tools(mcp: FastMCP) -> None:
     """Register web search tools on the MCP server."""
 
@@ -32,65 +94,13 @@ def register_web_search_tools(mcp: FastMCP) -> None:
             Résultats de recherche avec titre, URL et description
         """
         try:
-            import warnings
-
-            from duckduckgo_search import DDGS
-
-            warnings.filterwarnings("ignore")
-
             if ctx:
                 ctx.info(f"[WebSearch] Searching: {query}")
                 ctx.report_progress(0, 100, f"Searching: {query}")
 
-            results = []
-            ddgs = DDGS()
-
-            # Try text search first if requested
-            if search_type in ("text", "auto"):
-                try:
-                    for r in ddgs.text(query, region=region, max_results=limit):
-                        # Filter out non-French/English results for French queries
-                        url = r.get("href", "")
-                        if ".cn" not in url and "baidu" not in url:
-                            results.append(
-                                {
-                                    "title": r.get("title", ""),
-                                    "url": url,
-                                    "description": r.get("body", ""),
-                                    "type": "web",
-                                }
-                            )
-                except Exception as e:
-                    logger.debug(f"Text search failed: {e}")
-                    pass
-
-            # Fallback to news if text search returned poor results
-            if (search_type == "auto" and len(results) < 3) or search_type == "news":
-                try:
-                    for r in ddgs.news(query, region=region, max_results=limit):
-                        results.append(
-                            {
-                                "title": r.get("title", ""),
-                                "url": r.get("url", ""),
-                                "description": r.get("body", ""),
-                                "source": r.get("source", ""),
-                                "date": r.get("date", ""),
-                                "type": "news",
-                            }
-                        )
-                except Exception as e:
-                    logger.debug(f"News search failed: {e}")
-                    pass
-
-            # Deduplicate by URL
-            seen_urls = set()
-            unique_results = []
-            for r in results:
-                if r["url"] not in seen_urls:
-                    seen_urls.add(r["url"])
-                    unique_results.append(r)
-
-            results = unique_results[:limit]
+            results = await web_search_impl(
+                query, max_results=limit, region=region, search_type=search_type
+            )
 
             if ctx:
                 ctx.info(f"[WebSearch] Found {len(results)} results")

--- a/src/infrastructure/mcp/tools/web_search.py
+++ b/src/infrastructure/mcp/tools/web_search.py
@@ -24,42 +24,42 @@ async def web_search_impl(
 
     from duckduckgo_search import DDGS
 
-    warnings.filterwarnings("ignore")
-
     results: list[dict] = []
-    ddgs = DDGS()
 
-    if search_type in ("text", "auto"):
-        try:
-            for r in ddgs.text(query, region=region, max_results=max_results):
-                url = r.get("href", "")
-                if ".cn" not in url and "baidu" not in url:
-                    results.append(
-                        {
-                            "title": r.get("title", ""),
-                            "url": url,
-                            "description": r.get("body", ""),
-                            "type": "web",
-                        }
-                    )
-        except Exception as e:
-            logger.debug(f"Text search failed: {e}")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with DDGS() as ddgs:
+            if search_type in ("text", "auto"):
+                try:
+                    for r in ddgs.text(query, region=region, max_results=max_results):
+                        url = r.get("href", "")
+                        if ".cn" not in url and "baidu" not in url:
+                            results.append(
+                                {
+                                    "title": r.get("title", ""),
+                                    "url": url,
+                                    "description": r.get("body", ""),
+                                    "type": "web",
+                                }
+                            )
+                except Exception as e:
+                    logger.debug(f"Text search failed: {e}")
 
-    if (search_type == "auto" and len(results) < 3) or search_type == "news":
-        try:
-            for r in ddgs.news(query, region=region, max_results=max_results):
-                results.append(
-                    {
-                        "title": r.get("title", ""),
-                        "url": r.get("url", ""),
-                        "description": r.get("body", ""),
-                        "source": r.get("source", ""),
-                        "date": r.get("date", ""),
-                        "type": "news",
-                    }
-                )
-        except Exception as e:
-            logger.debug(f"News search failed: {e}")
+            if (search_type == "auto" and len(results) < 3) or search_type == "news":
+                try:
+                    for r in ddgs.news(query, region=region, max_results=max_results):
+                        results.append(
+                            {
+                                "title": r.get("title", ""),
+                                "url": r.get("url", ""),
+                                "description": r.get("body", ""),
+                                "source": r.get("source", ""),
+                                "date": r.get("date", ""),
+                                "type": "news",
+                            }
+                        )
+                except Exception as e:
+                    logger.debug(f"News search failed: {e}")
 
     seen_urls: set[str] = set()
     unique_results: list[dict] = []


### PR DESCRIPTION
## Summary

Two MCP tool modules referenced symbols that did not exist anywhere in the public baseline, causing one hard crash and one silent total failure.

**\`prospection.py\`** — when called with \`enrich=True\`, did \`from src.infrastructure.mcp.tools.web_search import web_search_impl\` followed by \`await web_search_impl(...)\`. But \`web_search.py\` only exported \`register_web_search_tools\`; the actual DuckDuckGo loop was a closure inside that registration function, unreachable from the outside. Every enrichment call raised \`ImportError\` mid-pipeline.

**\`benchmark.py\`** — imported \`bodacc_search\`, \`geocode_address\` and \`news_search\` from \`territorial_tools.py\`, none of which exist in the public baseline (only \`sirene_search\`, \`sirene_get\`, \`geo_locate\`, \`geo_map\`, \`geo_search_commune\`, \`aides_search\`, \`subventions_by_theme\` are defined there). Guarded by \`try/except ImportError\`, so the entire benchmark suite silently degraded to \`{\"error\": \"Import error: ...\"}\` on every call — running zero tests.

## Changes

- Extract the DuckDuckGo search loop into a module-level coroutine \`web_search_impl(query, max_results=10, region=\"fr-fr\", search_type=\"auto\") -> list[dict]\`. The MCP tool \`web_search\` now calls it and wraps the result in the existing JSON envelope; \`prospection.py\` keeps its existing call site (signature is compatible).
- Drop the three non-existent tools from \`benchmark.py\` (\`BENCHMARK_TESTS\` dict, \`tool_functions\` map, \`tool_configs\` map, docstring listings, error messages), leaving only the \`sirene_search\` tests the public baseline can actually run.

## Test plan

- [x] Static audit (\`ast\`-based reachability check on \`from src.X import Y\` across \`src/\`) reports zero broken imports.
- [x] \`python3 -c \"from src.infrastructure.mcp.tools.{web_search,benchmark,prospection} import ...\"\` loads cleanly.
- [x] \`inspect.signature(web_search_impl)\` matches the call site in \`prospection.py\` (\`web_search_impl(query, max_results=3)\`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web search now provides real-time progress reporting during queries.

* **Changes**
  * Benchmark test suite refined to focus on: sirene basic/advanced, market analysis, comparison, and prospect. Geocoding, news search, and bodacc search benchmarks have been removed.
  * Web search results improved with domain filtering for higher quality outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tawiza/tawiza/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->