### PR TITLE
docs: add module deep-dives for 6 src/ modules

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -290,7 +290,13 @@ Documentation détaillée pour chaque sous-système :
 [Knowledge Graph](docs/modules/knowledge-graph.md) ·
 [Signaux](docs/modules/signaux.md) ·
 [Investigation](docs/modules/investigation.md) ·
-[Décisions](docs/modules/decisions.md)
+[Décisions](docs/modules/decisions.md) ·
+[Core](docs/modules/core.md) ·
+[Application](docs/modules/application.md) ·
+[API](docs/modules/api.md) ·
+[MCP](docs/modules/mcp.md) ·
+[Collecteur](docs/modules/collector.md) ·
+[Scripts](docs/modules/scripts.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,13 @@ Detailed documentation for individual subsystems:
 [Knowledge Graph](docs/modules/knowledge-graph.md) ·
 [Signaux](docs/modules/signaux.md) ·
 [Investigation](docs/modules/investigation.md) ·
-[Decisions](docs/modules/decisions.md)
+[Decisions](docs/modules/decisions.md) ·
+[Core](docs/modules/core.md) ·
+[Application](docs/modules/application.md) ·
+[API](docs/modules/api.md) ·
+[MCP](docs/modules/mcp.md) ·
+[Collector](docs/modules/collector.md) ·
+[Scripts](docs/modules/scripts.md)
 
 ---
 

--- a/docs/modules/api.md
+++ b/docs/modules/api.md
@@ -1,0 +1,201 @@
+# API REST
+
+Backend FastAPI de Tawiza. Expose l'ensemble des capacités de la plateforme (agents, crawler, signaux territoriaux, alertes, modèles LLM, export) via une API HTTP versionnée, complétée par un canal WebSocket temps réel et des endpoints compatibles OpenAI.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    FastAPI app (main.py)                       │
+│                                                                │
+│  ┌──────────────────────── Middleware (LIFO) ──────────────┐  │
+│  │  RequestIDMiddleware  ·  ErrorHandlerMiddleware  ·       │  │
+│  │  PrometheusMiddleware  ·  CORS  ·  slowapi RateLimit     │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│                              │                                 │
+│  ┌───────────────────────────▼──────────────────────────────┐  │
+│  │                   Routers (~40 inclus)                     │  │
+│  │                                                            │  │
+│  │  v1/        →  routers organisés par domaine               │  │
+│  │  routers/   →  routers plats (ML, fine-tuning, browser…)   │  │
+│  └────────────────────────────────────────────────────────────┘  │
+│                              │                                 │
+│  ┌───────────────────────────▼──────────────────────────────┐  │
+│  │   WebSocket /ws  →  WebSocketManager + handlers PPDSL      │  │
+│  └────────────────────────────────────────────────────────────┘  │
+│                                                                │
+│  Lifespan : DB, AgentOrchestrator, schedulers (TAJINE,        │
+│  Crawler, Collector, News), broadcast métriques WebSocket     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+L'application est assemblée dans `main.py` : configuration du `lifespan` (initialisation base de données, `AgentOrchestrator`, schedulers, WebSocket), ajout des middlewares, puis inclusion des routers via `app.include_router(...)`.
+
+## Cycle de vie (lifespan)
+
+Au démarrage, le gestionnaire `lifespan` initialise dans l'ordre :
+
+1. Le logging structuré (`configure_logging`) et la télémétrie (`capture_startup`).
+2. La base de données (`init_db`), avec dégradation silencieuse si indisponible.
+3. L'`AgentOrchestrator` (sélection du modèle Ollama, agents).
+4. Le `WebSocketManager` et ses handlers, plus le broadcast périodique de métriques (intervalle 5 s).
+5. Les schedulers : TAJINE, Crawler, Collector (micro-signaux), News Intelligence (intervalle 6 h).
+
+À l'arrêt, les schedulers et le broadcast de métriques sont stoppés, le pool de connexions et la base de données sont fermés.
+
+## Middleware
+
+| Middleware | Rôle |
+|------------|------|
+| `RequestIDMiddleware` | Génère ou propage un `X-Request-ID` (corrélation logs/traces) |
+| `ErrorHandlerMiddleware` | Capture les exceptions et renvoie une réponse JSON normalisée |
+| `PrometheusMiddleware` | Mesure la durée des requêtes (exposée sur `/metrics`) |
+| `CORSMiddleware` | Origines configurables via `CORS_ORIGINS` |
+| slowapi `Limiter` | Rate limiting par IP sur les endpoints décorés |
+
+Le middleware `security.py` (`SecurityHeadersMiddleware`, `RateLimitMiddleware`, `RequestValidationMiddleware`) fournit des en-têtes de sécurité, un rate limiting par token bucket et une validation de taille/Content-Type. Il est disponible dans le module mais n'est pas câblé dans `main.py`.
+
+Les handlers d'exception FastAPI (`register_exception_handlers`) normalisent les erreurs domaine (`TawizaError`), de validation (`RequestValidationError`) et HTTP en réponses `{success, error, request_id}`.
+
+## Routers
+
+Les routers sont organisés en deux espaces :
+
+- `v1/` : routers groupés par domaine, chacun dans un sous-package avec `routes.py` (et parfois `schemas.py`).
+- `routers/` : routers plats, principalement orientés ML, entraînement et outils.
+
+### Routers `v1/` (par domaine)
+
+| Domaine | Prefix | Description |
+|---------|--------|-------------|
+| `auth/` | `/api/v1/auth` | Authentification (login admin via `ADMIN_EMAIL`/`ADMIN_PASSWORD`) |
+| `agents/` | `/api/v1/agents` | Endpoints des agents Tawiza |
+| `tajine/` | `/api/v1/tajine` | Méta-agent TAJINE (cycle PPDSL) |
+| `orchestration/` | `/orchestration` | Orchestration de pipelines |
+| `conversations/` | `/api/v1/conversations` | Historique de conversations |
+| `crawler/` | `/crawler` | Configuration du crawler |
+| `crawler/commoncrawl_routes` | `/api/v1/crawler/commoncrawl` | CrawlIntel (Common Crawl) |
+| `crawler_v2.py` | `/api/v1/crawler` | Gestion du crawler V2 |
+| `alerts/` | `/alerts` | Alertes territoriales |
+| `territorial/` | `/territorial` | Widgets du tableau de bord territorial |
+| `sources/` | `/api/v1/sources` | Santé et monitoring des sources de données |
+| `signals.py` | `/api/v1/signals` | Signaux et micro-signaux (base tawiza) |
+| `microsignals.py` | `/api/v1/microsignals` | Gestion des micro-signaux |
+| `investigation.py` | `/api/v1/investigation` | Investigation |
+| `relations.py` | `/api/v1/investigation/relations` | Relations entre entités |
+| `decisions/` | `/api/v1/decisions` | Décisions et parties prenantes |
+| `watcher/` | `/api/v1/watcher` | Daemon Watcher et alertes |
+| `schedules/` | `/schedules` | Analyses planifiées |
+| `export/` | `/api/v1/export` | Export PDF/Markdown |
+| `health/` | `/api/v1/health` | Health checks détaillés |
+| `ollama/` | `/api/v1/ollama` | Gestion des modèles Ollama |
+| `openai_compatible/` | `/v1` | Endpoints compatibles OpenAI (LobeChat) |
+| `training.py` | `/api/v1/training` | Données d'entraînement |
+| `errors/` | `/api/v1/errors` | Remontée d'erreurs frontend |
+
+### Routers `routers/` (ML et outils)
+
+| Router | Prefix | Description |
+|--------|--------|-------------|
+| `annotations.py` | `/api/v1/annotations` | Annotations |
+| `browser.py` | `/api/v1/browser` | Automatisation navigateur |
+| `fine_tuning.py` | `/api/v1/fine-tuning` | Fine-tuning |
+| `health.py` | `/health` | Health checks |
+| `ollama.py` | (variable) | Gestion Ollama |
+| `code_execution.py` | `/api/v1/code-execution` | Exécution de code |
+| `ecocartographe.py` | `/ecocartographe` | EcoCartographe |
+| `active_learning.py` | `/active-learning` | Active learning |
+| `uaa.py` | `/uaa` | Unified Adaptive Agent |
+| `vectors.py` | `/vectors` | Recherche vectorielle |
+| `retraining.py` | `/retraining` | Réentraînement |
+| `progress.py` | (variable) | Suivi de progression des tâches |
+| `models.py`, `model_storage.py`, `prompts.py`, `datasets.py`, `predictions_v2.py`, `feedback_v2.py`, `training.py` | (variable) | Cycle de vie ML : modèles, prompts, datasets, prédictions, feedback |
+
+Tous les routers `v1/` ne sont pas inclus dans `main.py` (certains, comme `routers/ecocartographe.py` ou `routers/active_learning.py`, ne sont pas câblés par défaut).
+
+## WebSocket (`websocket/`)
+
+Le canal `/ws` assure la communication temps réel avec la TUI et le frontend.
+
+- `server.py` : `WebSocketManager` gère les connexions par session, le routage de messages, le broadcast (ciblé par session ou global) et la diffusion périodique de métriques système (CPU, RAM, GPU via `rocm-smi`, disque).
+- `handlers.py` : enregistre les handlers métier  -  `TaskHandler` (création/contrôle de tâches via `AgentOrchestrator`), `ChatHandler` (chat streaming), `AgentStatusHandler`, `TAJINEHandler` (pont des événements PPDSL vers la TUI), `BrowserHandler` (streaming de captures d'écran).
+- `models.py` : modèles Pydantic des messages (énum `MessageType`, messages Task/TAJINE/Chat/Browser/System) et fonction `parse_message`.
+
+Le mapping `TAJINEHandler.EVENT_MAP` relaie les phases du cycle PPDSL (`perceive`, `plan`, `delegate`, `synthesize`, `learn`) vers les messages WebSocket correspondants.
+
+## Endpoints racine
+
+Définis directement dans `main.py` :
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /` | Métadonnées de l'API |
+| `GET /health` | Health check simple |
+| `GET /metrics` | Métriques Prometheus |
+| `GET /api/v1/system/status` | CPU/RAM/disque via `psutil` |
+| `GET/POST /api/v1/evaluations` | Évaluations (placeholder) |
+| `WS /ws` | Canal WebSocket temps réel |
+| `GET /ws/status` | État du serveur WebSocket |
+
+La documentation interactive est exposée sur `/docs` (Swagger) et `/redoc`.
+
+## Fichiers clés
+
+```
+src/interfaces/api/
+├── main.py                      # App FastAPI : lifespan, middlewares, inclusion routers
+├── middleware/
+│   ├── request_id.py            # Corrélation X-Request-ID
+│   ├── error_handler.py         # Réponses d'erreur normalisées
+│   └── security.py              # En-têtes sécurité, rate limit, validation
+├── websocket/
+│   ├── server.py                # WebSocketManager + broadcast métriques
+│   ├── handlers.py              # Handlers Task/Chat/TAJINE/Browser
+│   └── models.py                # Modèles de messages Pydantic
+├── v1/                          # Routers par domaine (routes.py + schemas.py)
+│   ├── auth/  agents/  tajine/  orchestration/  conversations/
+│   ├── crawler/  alerts/  territorial/  sources/  decisions/
+│   ├── watcher/  schedules/  export/  health/  ollama/
+│   ├── openai_compatible/  errors/
+│   ├── signals.py  microsignals.py  investigation.py
+│   ├── relations.py  crawler_v2.py  training.py
+│   └── relations_schemas.py
+└── routers/                     # Routers plats (ML, outils)
+    ├── annotations.py  browser.py  fine_tuning.py  code_execution.py
+    ├── ecocartographe.py  active_learning.py  uaa.py  vectors.py
+    ├── retraining.py  progress.py  health.py  ollama.py
+    ├── models.py  model_storage.py  prompts.py  datasets.py
+    └── predictions_v2.py  feedback_v2.py  training.py
+```
+
+## Configuration
+
+| Variable | Description | Défaut |
+|----------|-------------|--------|
+| `CORS_ORIGINS` | Origines autorisées (séparées par virgule) | localhost:3000/8000 |
+| `APP_ENV` | Environnement (`development`/`production`) | `development` |
+| `LOG_LEVEL` | Niveau de log | `INFO` |
+| `ENVIRONMENT` | Environnement Sentry | `development` |
+| `SENTRY_DSN` | DSN Sentry (tracking d'erreurs, optionnel) |  -  |
+| `ADMIN_EMAIL` | Email du compte admin (auth) |  -  |
+| `ADMIN_PASSWORD` | Mot de passe admin (auth) |  -  |
+| `ADMIN_NAME` | Nom affiché de l'admin | `Administrateur` |
+| `SECRET_KEY` | Clé de signature JWT (obligatoire en production) | clé temporaire en dev |
+| `OLLAMA_BASE_URL` | URL Ollama (endpoints compatibles OpenAI) | `http://localhost:11434` |
+
+Le rate limiting global est appliqué par `slowapi` (`get_remote_address`) sur les endpoints racine (60/minute). L'intégration Sentry est optionnelle : activée uniquement si `sentry-sdk` est installé et `SENTRY_DSN` défini.
+
+## État actuel
+
+- L'API FastAPI versionnée et le canal WebSocket sont fonctionnels et servent la TUI et le frontend.
+- Les middlewares de corrélation, gestion d'erreurs et métriques Prometheus sont câblés dans `main.py`.
+- Les schedulers (TAJINE, Crawler, Collector, News) démarrent au boot avec dégradation silencieuse si une dépendance est indisponible.
+- Le broadcast de métriques WebSocket s'appuie sur `rocm-smi` pour le GPU (renvoie 0 si absent).
+- Les endpoints d'évaluations (`/api/v1/evaluations`) sont des placeholders.
+
+## Limitations connues
+
+- Tous les routers présents dans `v1/` et `routers/` ne sont pas inclus dans `main.py` : certains existent dans le code sans être câblés.
+- `SecurityHeadersMiddleware`/`RateLimitMiddleware`/`RequestValidationMiddleware` sont implémentés mais pas ajoutés à l'application principale.
+- Le préfixe `/api/v1/crawler` est partagé entre `crawler_v2.py` et les routes CrawlIntel (`commoncrawl_routes`), ce qui demande une attention au regroupement des routes.
+- L'initialisation de la base de données et des schedulers échoue silencieusement (warning) si les dépendances ne sont pas disponibles, ce qui peut masquer un démarrage partiel.

--- a/docs/modules/application.md
+++ b/docs/modules/application.md
@@ -1,0 +1,223 @@
+# Couche Application
+
+Couche applicative de Tawiza (architecture hexagonale). Elle orchestre la logique métier entre le domaine et l'infrastructure : services, cas d'usage, ports (interfaces), DTOs, jobs planifiés, orchestration multi-sources, génération de rapports et gestion conversationnelle. Aucun accès direct aux dépendances externes - tout passe par des ports implémentés dans `src/infrastructure/`.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         src/application/                           │
+│                                                                    │
+│  ┌────────────────┐  ┌──────────────┐  ┌─────────────────────┐     │
+│  │   use_cases/   │  │    ports/    │  │       dtos/         │     │
+│  │  Orchestration │─▶│  Interfaces  │  │  Requêtes/Réponses  │     │
+│  │  ML (train,    │  │  (ABC/       │  │  (Pydantic/         │     │
+│  │  deploy, ...)  │  │  Protocol)   │  │  dataclass)         │     │
+│  └────────────────┘  └──────┬───────┘  └─────────────────────┘     │
+│                             │ implémentés par infrastructure        │
+│  ┌──────────────────────────▼──────────────────────────────────┐  │
+│  │                        services/                              │  │
+│  │                                                               │  │
+│  │  ┌─────────────────────┐  ┌──────────────────────────────┐   │  │
+│  │  │  Graphe relationnel │  │  Intelligence territoriale   │   │  │
+│  │  │  extractors (L1)    │  │  department_scorer           │   │  │
+│  │  │  inferrers   (L2)   │  │  ecosystem_score             │   │  │
+│  │  │  predictors  (L3)   │  │  focal_point_detector        │   │  │
+│  │  │  relation_service   │  │  correlation_engine          │   │  │
+│  │  │  network_analytics  │  │  territorial_stats / reports │   │  │
+│  │  └─────────────────────┘  └──────────────────────────────┘   │  │
+│  │                                                               │  │
+│  │  ┌─────────────────────┐  ┌──────────────────────────────┐   │  │
+│  │  │  Pipeline news      │  │  Agents & LLM                │   │  │
+│  │  │  news_sync          │  │  agent_orchestrator          │   │  │
+│  │  │  news_cross_enricher│  │  autonomous_agent_service    │   │  │
+│  │  │  news_scheduler     │  │  assistant_service           │   │  │
+│  │  │  llm_summarizer     │  │  embedding_service           │   │  │
+│  │  └─────────────────────┘  └──────────────────────────────┘   │  │
+│  │                                                               │  │
+│  │  ┌──────────────────────────────────────────────────────┐    │  │
+│  │  │  Planification (APScheduler)                          │    │  │
+│  │  │  crawler_scheduler · tajine_scheduler                 │    │  │
+│  │  └──────────────────────────────────────────────────────┘    │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+│                                                                    │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────┐  ┌────────────┐  │
+│  │ orchestration│  │  reporting/  │  │  jobs/   │  │conversation│  │
+│  │ multi-source │  │  HTML report │  │ collecte │  │ assistant  │  │
+│  └──────────────┘  └──────────────┘  └──────────┘  └────────────┘  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Sous-modules
+
+### `services/` - Logique métier
+
+Le sous-module le plus volumineux. Les services suivent le principe de responsabilité unique et l'injection de dépendances.
+
+#### Graphe relationnel (3 niveaux de confiance)
+
+Le cœur de l'analyse territoriale est un graphe d'acteurs et de relations construit en trois niveaux d'abstraction croissante :
+
+| Niveau | Fichier | `relation_type` | Confiance | Description |
+|--------|---------|-----------------|-----------|-------------|
+| **L1** | `relation_extractors.py` | `extracted` | élevée | Extraction factuelle depuis SIRENE, BODACC, BOAMP, RNA, subventions, EPCI, incubateurs, pôles |
+| **L2** | `relation_inferrers.py` | `inferred` | `[0.40, 0.79]` | Inférence statistique (corrélations) sur les acteurs déjà persistés |
+| **L3** | `relation_predictors.py` | `hypothetical` | `[0.05, 0.39]` | Prédiction de scénarios futurs et de liens probabilistes |
+
+- `relation_service.py` : orchestrateur (`RelationService`) exposant `discover()`, `get_graph()` (payload D3.js), `get_coverage()` et `get_gaps()`. Utilise les registres `EXTRACTORS`, `INFERRERS`, `PREDICTORS`.
+- `cascade_model.py` : régression logistique légère prédisant la probabilité de cascade (remplace l'heuristique `propagation_factor * confidence * 0.5`), avec repli heuristique si scikit-learn est indisponible.
+- `network_analytics_service.py` : métriques de graphe via NetworkX (centralité, détection de communautés, résilience, trous structurels, approximation de Shapley, scoring de risque par acteur).
+
+Les acteurs et relations utilisent des UUID déterministes (`uuid5` avec `NAMESPACE_DNS`) pour des UPSERT stables d'une exécution à l'autre.
+
+#### Intelligence territoriale
+
+- `department_scorer.py` : indice de santé départemental (0-100), adapté du Country Instability Index de World Monitor. Formule : `baseline * 0.4 + event_score * 0.6 + boosts`, plancher à 15.
+- `ecosystem_score_service.py` : score de maturité d'écosystème à 6 dimensions pondérées (tissu économique 25 %, structures support 20 %, maillage institutionnel 15 %, formation & recherche 15 %, emploi & compétences 15 %, foncier & infrastructure 10 %).
+- `focal_point_detector.py` : détecte les entités (ORG, LOC, PER) apparaissant dans plusieurs sources de presse indépendantes (convergence ≥ 2 sources, fenêtre 48 h).
+- `correlation_engine.py` : corrélations cachées entre indicateurs - corrélations décalées (lag), causalité de Granger, information mutuelle, corrélation partielle.
+- `territorial_stats.py` : statistiques territoriales réelles (SIRENE, BODACC, INSEE) - aucune donnée mock.
+- `territorial_reports.py` : génération de rapports automatiques (flash quotidien, hebdo régional, mensuel national).
+
+#### Pipeline news
+
+- `news_sync_service.py` : synchronisation des flux RSS vers la base (fetch → dédoublonnage → persistance → résumé → sentiment → détection de pics → alerte).
+- `news_cross_enricher.py` : crée des relations `mentioned_in_news` reliant un acteur connu à son territoire lorsqu'un focal point correspond.
+- `news_scheduler.py` : pipeline périodique (sync + enrichissement + détection de focal points + santé départementale + alertes Telegram).
+- `llm_summarizer.py` : résumé et sentiment d'article avec chaîne de repli Ollama → Groq → OpenRouter, chaque fournisseur protégé par un circuit breaker.
+- `alert_service.py` : détection et notification des changements significatifs (création/fermeture d'entreprise, opportunité de marché, indicateur économique, etc.).
+
+#### Agents, LLM & assistant
+
+- `agent_orchestrator.py` : routage des requêtes vers les agents ou LLMs appropriés, avec émission d'événements pour l'intégration WebSocket TUI (`started`, `thinking`, `tool_call`, `streaming`, …).
+- `autonomous_agent_service.py` : coordination de l'automatisation web autonome (planification LLM → validation → exécution pas-à-pas → reprise sur erreur).
+- `assistant_service.py` : interface conversationnelle principale, orchestrant `conversation/` avec RAG optionnel.
+- `embedding_service.py` : chunking, génération d'embeddings et stockage vectoriel (PGVector), Ollama direct ou via LitServe.
+
+#### Planification & système
+
+- `crawler_scheduler.py` : intègre `AdaptiveCrawler` avec APScheduler pour le crawling automatique des sources officielles françaises (SIRENE, BODACC, …).
+- `tajine_scheduler.py` : analyses TAJINE planifiées via APScheduler avec job store PostgreSQL.
+- `system_initialization_service.py` : orchestration de l'initialisation système (vérification, création de répertoires).
+- `service_factory.py` : fonctions factory façade sur le conteneur DI.
+- `interfaces.py` : `Protocol` des services système (vérification, initialisation, health check, GPU, répertoires).
+- `_db_pool.py` : pool de connexions asyncpg partagé par les services du graphe relationnel.
+
+### `use_cases/` - Cas d'usage ML
+
+Cas d'usage orchestrant le cycle de vie des modèles ML, dépendant uniquement des ports et des repositories du domaine.
+
+| Fichier | Cas d'usage |
+|---------|-------------|
+| `train_model.py` | Entraînement d'un nouveau modèle (LoRA) |
+| `deploy_model.py` | Déploiement avec stratégie (canary, blue-green) et rollback |
+| `predict.py` | Prédiction avec routage de trafic et journalisation |
+| `submit_feedback.py` | Soumission de feedback utilisateur sur les prédictions |
+| `active_learning.py` | Détection de drift, échantillonnage et déclenchement de réentraînement |
+| `automatic_retraining.py` | Réentraînement automatique selon des conditions (dégradation, intervalle) |
+
+### `ports/` - Interfaces (hexagonal)
+
+Contrats (ABC / Protocol) implémentés par la couche infrastructure :
+
+- `ml_ports.py` : `IModelTrainer`, `IModelDeployer`, `IModelInference`, `IMLExperimentTracker`, `IWorkflowOrchestrator`
+- `storage_ports.py` : `IModelStorageService` (stockage S3-compatible / MinIO)
+- `active_learning_ports.py` : `ISamplingStrategy`, `IDriftDetector`, `IRetrainingTrigger`
+- `annotation_ports.py` : `IAnnotationService` (ex. Label Studio)
+- `agent_ports.py` : contrats des agents d'automatisation web (`AgentType`, `TaskStatus`)
+
+### `dtos/` - Data Transfer Objects
+
+- `ml_dtos.py` : DTOs ML (`TrainModelRequest`, `DeployModelRequest`, `PredictionRequest`, …) en `dataclass`
+- `active_learning_dtos.py` : DTOs Active Learning (Pydantic, ex. `SelectSamplesRequest`)
+- `code_execution_dtos.py` : DTOs d'exécution de code (`ExecutionBackend`, `CodeLanguage`)
+
+### `orchestration/` - Requêtes multi-sources
+
+- `data_orchestrator.py` : `DataOrchestrator` lance des requêtes parallèles sur plusieurs sources de données, agrège les résultats et applique le matching d'entités (`EntityMatcher`).
+
+### `reporting/` - Rapports
+
+- `orchestrated_report.py` : `OrchestratedReportGenerator` génère des rapports HTML riches (résumé exécutif avec score de confiance, ventilation par source, timeline de validation multi-agents, recommandations, visualisations).
+
+### `jobs/` - Tâches de collecte
+
+- `territorial_collector.py` : job de collecte quotidienne parcourant les 101 départements français et stockant les métriques historiques.
+
+### `conversation/` - Gestion conversationnelle
+
+- `context_manager.py` : `ContextManager` / `ConversationContext` - état, historique et contexte de conversation.
+- `dialog_manager.py` : `DialogManager` / `DialogState` - flux de dialogue (idle, greeting, helping, clarifying, …).
+- `response_generator.py` : `ResponseGenerator` - réponses contextuelles via LLM (Ollama / LitServe).
+
+## Fichiers clés
+
+```
+src/application/
+├── services/
+│   ├── relation_service.py            # Orchestrateur du graphe relationnel
+│   ├── relation_extractors.py         # L1 - extraction factuelle
+│   ├── relation_inferrers.py          # L2 - inférence statistique
+│   ├── relation_predictors.py         # L3 - prédiction
+│   ├── cascade_model.py               # Régression logistique cascade
+│   ├── network_analytics_service.py   # Métriques NetworkX
+│   ├── department_scorer.py           # Indice de santé départemental
+│   ├── ecosystem_score_service.py     # Score de maturité 6 dimensions
+│   ├── focal_point_detector.py        # Convergence multi-sources
+│   ├── correlation_engine.py          # Corrélations cachées
+│   ├── territorial_stats.py           # Stats réelles SIRENE/BODACC/INSEE
+│   ├── territorial_reports.py         # Rapports automatiques
+│   ├── news_sync_service.py           # Sync RSS → DB
+│   ├── news_cross_enricher.py         # Enrichissement graphe via news
+│   ├── news_scheduler.py              # Pipeline news périodique
+│   ├── llm_summarizer.py              # Résumé + sentiment (fallback chain)
+│   ├── alert_service.py               # Alertes sur changements
+│   ├── agent_orchestrator.py          # Routage agents/LLM (WebSocket TUI)
+│   ├── autonomous_agent_service.py    # Automatisation web autonome
+│   ├── assistant_service.py           # Assistant conversationnel
+│   ├── embedding_service.py           # Embeddings + stockage vectoriel
+│   ├── crawler_scheduler.py           # Planification du crawler
+│   ├── tajine_scheduler.py            # Planification des analyses TAJINE
+│   ├── system_initialization_service.py
+│   ├── service_factory.py             # Factory / façade DI
+│   ├── interfaces.py                  # Protocols services système
+│   └── _db_pool.py                    # Pool asyncpg partagé
+├── use_cases/                         # Cas d'usage ML (train, deploy, predict, …)
+├── ports/                             # Interfaces (ml, storage, active_learning, …)
+├── dtos/                              # DTOs (ml, active_learning, code_execution)
+├── orchestration/data_orchestrator.py # Requêtes multi-sources parallèles
+├── reporting/orchestrated_report.py    # Rapports HTML
+├── jobs/territorial_collector.py       # Collecte quotidienne 101 départements
+└── conversation/                       # Contexte, dialogue, génération de réponse
+```
+
+## Configuration
+
+Variables d'environnement utilisées par la couche application :
+
+| Variable | Description | Défaut |
+|----------|-------------|--------|
+| `COLLECTOR_DATABASE_URL` | DSN PostgreSQL du pool asyncpg partagé (`_db_pool.py`) | `postgresql+asyncpg://localhost:5432/tawiza` |
+| `OLLAMA_BASE_URL` | URL du serveur Ollama (LLM local) | `http://localhost:11434` |
+| `OLLAMA_MODEL` | Modèle Ollama par défaut | - |
+| `GROQ_API_KEY` | Clé API Groq (2ᵉ maillon du fallback LLM) | - |
+| `OPENROUTER_API_KEY` | Clé API OpenRouter (3ᵉ maillon du fallback LLM) | - |
+| `TELEGRAM_BOT_TOKEN` | Token du bot Telegram pour les alertes | - |
+| `TELEGRAM_CHAT_ID` | Identifiant du chat Telegram destinataire | - |
+
+## État actuel
+
+- Le graphe relationnel à 3 niveaux (extractors / inferrers / predictors) est fonctionnel avec UPSERT déterministe.
+- Le pipeline news (sync → enrichissement → focal points → alertes) tourne via `news_scheduler`.
+- Les scores territoriaux (santé départementale, maturité d'écosystème) sont opérationnels sur données réelles.
+- La chaîne de repli LLM (Ollama → Groq → OpenRouter) est protégée par circuit breakers.
+- Les cas d'usage ML s'appuient sur les ports : l'implémentation infrastructure conditionne leur activation effective.
+- `cascade_model` retombe sur l'heuristique si scikit-learn ou les données d'entraînement manquent.
+
+## Limitations connues
+
+- Le pool asyncpg (`_db_pool`) est un singleton global partagé - pas d'isolation par tenant.
+- Le modèle de cascade nécessite des données d'entraînement suffisantes, sinon repli heuristique.
+- Les schedulers APScheduler perdent leur état au redémarrage si le job store PostgreSQL n'est pas configuré.
+- L'enrichissement news → graphe dépend de la qualité du NER pour le matching d'acteurs.
+- Plusieurs services (corrélation, prédiction L3) nécessitent un historique de données suffisant pour produire des résultats fiables.

--- a/docs/modules/collector.md
+++ b/docs/modules/collector.md
@@ -1,0 +1,223 @@
+# Collector
+
+Pipeline de collecte de micro-signaux territoriaux. Interroge des sources publiques françaises (APIs + crawling), normalise les données, détecte des anomalies par recoupement, puis calcule des scores territoriaux quantitatifs. Le tout est orchestré par un scheduler et exposé via une API REST.
+
+## Positionnement vs Data Hunter et Crawler
+
+Trois modules manipulent des sources de données, avec des rôles distincts :
+
+- **Collector** (ce module) : pipeline de fond **autonome et planifié**. Collecte en continu sur un ensemble fixe de départements, écrit dans la table `signals` PostgreSQL, et calcule des scores territoriaux. Indépendant de l'agent.
+- **Data Hunter** (voir `data-hunter.md`) : collecte **à la demande**, déclenchée par l'agent TAJINE pour répondre à une requête utilisateur (4 stratégies adaptatives).
+- **Crawler** (voir `crawler.md`) : moteur de crawling web générique avec MAB, utilisé comme **renfort** par le Data Hunter. Le Collector a son propre pipeline de crawling presse (`crawling/`), plus simple et spécialisé.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                       CollectorScheduler                          │
+│              (APScheduler - jobs cron + watchdog réseau)          │
+└───────────────┬──────────────────────────────┬──────────────────┘
+                │                               │
+       ┌────────▼─────────┐           ┌─────────▼──────────┐
+       │   collectors/    │           │     crawling/      │
+       │  APIs (13)       │           │  Presse locale     │
+       │  + crawlers (2)  │           │  Trafilatura + NLP │
+       └────────┬─────────┘           └─────────┬──────────┘
+                │                               │
+                │      ┌──────────────────┐     │
+                └─────▶│   processing/    │◀────┘
+                       │ NLP · Geo · OCR  │
+                       └────────┬─────────┘
+                                │
+                       ┌────────▼─────────┐
+                       │    storage/      │
+                       │ signals (PG)     │
+                       └────────┬─────────┘
+                                │
+            ┌───────────────────┼───────────────────┐
+            │                   │                    │
+   ┌────────▼────────┐ ┌────────▼────────┐ ┌─────────▼────────┐
+   │  crossref +     │ │     quant/      │ │      epci/       │
+   │  detection/     │ │ scoring · qlib  │ │ scores par       │
+   │  anomalies      │ │ ML · temporel   │ │ intercommunalité │
+   └─────────────────┘ └─────────────────┘ └──────────────────┘
+```
+
+## Composants
+
+### Collecteurs (`collectors/`)
+
+Tous les collecteurs héritent de `BaseCollector` (`collectors/base.py`), qui fournit rate limiting (token bucket), retry avec backoff exponentiel, client HTTP mutualisé et statistiques. Chaque collecteur produit des `CollectedSignal` (source, date, code géographique, métrique, type de signal, confiance).
+
+Collecteurs API (`collectors/api/`) :
+
+| Collecteur | Source | Données |
+|------------|--------|---------|
+| `sirene.py` | INSEE SIRENE | Créations / radiations d'entreprises |
+| `bodacc.py` | BODACC | Procédures collectives (liquidations, redressements) |
+| `france_travail.py` | France Travail | Offres d'emploi |
+| `dvf.py` | DVF | Transactions immobilières, prix au m² |
+| `sitadel.py` | Sitadel | Permis de construire (logements + locaux) |
+| `dgfip.py` | DGFiP | Données fiscales (data.economie.gouv.fr) |
+| `urssaf.py` | URSSAF | Emploi et cotisations sociales |
+| `caf.py` | CAF | Prestations sociales |
+| `education_nationale.py` | Éducation Nationale | Données scolaires |
+| `banque_france.py` | Banque de France | Statistiques de défaillances |
+| `google_trends.py` | Google Trends | Intérêt de recherche par région |
+| `gdelt.py` | GDELT | Signaux presse (GDELT v2 Doc API) |
+| `commoncrawl.py` | Common Crawl | Intelligence web via snapshots archivés (LLM + WARC) |
+
+Crawlers (`collectors/crawlers/`) :
+
+| Crawler | Cible | Détail |
+|---------|-------|--------|
+| `presse_locale.py` | Presse régionale | Flux RSS + extraction Trafilatura |
+| `leboncoin.py` | LeBonCoin | Signaux de détresse d'entreprises (Playwright anti-bot) |
+
+### Pipeline de crawling (`crawling/`)
+
+Le `CrawlingPipeline` (`crawling/pipeline.py`) est l'algorithme cœur de détection de micro-signaux presse, en 8 étapes : découverte d'URL → fetch (Trafilatura, fallback Playwright) → extraction de texte → analyse NLP (mots-clés + NER spaCy) → scoring de confiance → résolution géographique → stockage → recoupement.
+
+Les règles de signal (`SignalRule`) mappent des listes de mots-clés français à un type (`positif`, `negatif`, `neutre`) et une métrique.
+
+`crawling/crossref.py` contient le moteur de **détection cross-source** : il recoupe les signaux de plusieurs sources via des `CrossRefPattern` (z-score par condition, minimum de sources convergentes) pour produire des `MicroSignal` (déclin territorial, dynamisme territorial, tension emploi, crise sectorielle). Les micro-signaux détectés sont persistés en tant qu'anomalies.
+
+### Traitement (`processing/`)
+
+| Fichier | Rôle |
+|---------|------|
+| `nlp.py` | `FrenchNLP` : NER spaCy français (LOC, ORG, PER, MISC) |
+| `geocoder.py` | Résolution géographique via `french-cities` (commune → INSEE, code postal → commune, commune → département/EPCI) |
+| `ocr.py` | OCR de documents (PDF BODACC, captures, permis) via GLM-OCR sur Ollama |
+| `contextualizer.py` | Génération de descriptions lisibles des anomalies via Ollama (LLM local) |
+
+### Stockage (`storage/`)
+
+Modèles SQLAlchemy (`storage/models.py`) :
+- `Signal` : table unifiée `signals` pour tous les signaux collectés (source, localisation, métrique, type, confiance, données brutes JSONB). Contrainte d'unicité `(source, source_url, event_date)`.
+- `Anomaly` : table `anomalies` pour les détections cross-source.
+
+`storage/repository.py` expose `SignalRepository` : repository asynchrone (asyncpg) avec init de schéma, insertion par batch et requêtes filtrées.
+
+### Détection (`detection/`)
+
+`detection/anomaly.py` : détection statistique d'anomalies sur les signaux (z-score, IQR en baseline, PyOD pour le multivarié avancé). Produit des `DetectedAnomaly` classés par `classify_anomaly`. Complémentaire du recoupement cross-source de `crawling/crossref.py`.
+
+### Analyse quantitative (`quant/`)
+
+Inspirée de la finance quantitative, adaptée au territoire. Décomposée en phases :
+
+| Fichier | Phase | Rôle |
+|---------|-------|------|
+| `factors.py` | 2 | Calcul des facteurs alpha normalisés par département |
+| `scoring.py` | 2 | Score de santé territoriale composite (z-score, pondération) |
+| `population.py` | - | Population INSEE 2024 pour normalisation |
+| `temporal.py` | 3 | Moyennes mobiles, taux de variation, corrélations à retard cross-source |
+| `trends.py` | 3 | Détection de changements de tendance (croisements MA + ROC + facteurs) |
+| `factor_mining.py` | 4 | Génération et test d'hypothèses de facteurs via Ollama (Information Coefficient) |
+| `ml_detection.py` | 4 | Détection non supervisée (Isolation Forest) et clustering (HDBSCAN/DBSCAN) |
+
+Le sous-module `quant/qlib/` adapte les concepts du `DataHandler` de Microsoft QLib à l'intelligence territoriale : les « instruments » deviennent des « territoires » (départements), les métriques financières deviennent des indicateurs territoriaux, et l'analyse est cross-sectionnelle entre territoires.
+
+- `handler.py` : `TerritorialDataHandler`, orchestrateur (charge PostgreSQL, applique les chaînes de traitement, génère les features)
+- `expressions.py` : bibliothèque d'`ALPHA_EXPRESSIONS` prédéfinies
+- `ops.py` : opérateurs d'expressions alpha (fonctions sur Series/DataFrame MultiIndex date/territoire)
+- `processor.py` : transformateurs de données chaînables
+- `dataset.py` : `TerritorialDataset`, abstraction pour les workflows ML
+
+### Granularité EPCI (`epci/`)
+
+Analyse au niveau intercommunalité plutôt que département.
+
+- `referentiel.py` : mapping des ~34 871 communes vers leurs ~1 255 EPCIs, téléchargé et caché depuis geo.api.gouv.fr
+- `enrichment.py` : enrichissement par batch des signaux existants (ajout de `code_epci` à partir de `code_commune`)
+- `scoring.py` : scoring composite agrégé au niveau EPCI
+
+### Scheduler (`scheduler/`)
+
+`scheduler/jobs.py` - `CollectorScheduler` (APScheduler) tourne dans le cycle de vie du backend FastAPI. Jobs configurés :
+
+| Job | Fréquence | Contenu |
+|-----|-----------|---------|
+| `api_collectors` | Quotidien 6h + 18h | Collecteurs API sur tous les départements |
+| `crawling_pipeline` | Toutes les 4h | Pipeline presse locale (Trafilatura + NLP) |
+| `cross_source_detection` | Quotidien 7h | Détection cross-source post-collecte |
+| `crawlintel` | Hebdo (dimanche 2h) | Common Crawl (rotation de 3 départements/run) |
+| `network_watchdog` | Toutes les 15 min | Relance la collecte au retour du réseau |
+
+Les départements surveillés (`MONITORED_DEPARTMENTS`) couvrent les 15 plus grandes aires urbaines françaises + l'Île-de-France. Les collecteurs lourds (`google_trends`, `presse_locale`, `commoncrawl`) sont **lazy-loaded**.
+
+### API (`api.py`)
+
+Routeur FastAPI préfixé `/api/collector` (rate-limité via slowapi). Principaux endpoints : `signals`, `signals/summary`, `anomalies`, `ranking`, `departments/heatmap`, `departments/scores`, `departments/{dept}/factors`, `departments/{dept}/trends`, `trends/alerts`, `correlations`, `ml/anomalies`, `ml/clusters`, `ml/factors`, `qlib/expressions`, `qlib/features`, `timeline`, `epci/scores`, `scheduler/status`, `run/{collector_name}`.
+
+## Fichiers clés
+
+```
+src/collector/
+├── api.py                      # Endpoints FastAPI (/api/collector)
+├── collectors/
+│   ├── base.py                 # BaseCollector + CollectedSignal
+│   ├── api/                    # 13 collecteurs API (SIRENE, BODACC, DVF, ...)
+│   └── crawlers/               # presse_locale.py, leboncoin.py
+├── crawling/
+│   ├── pipeline.py             # CrawlingPipeline (8 étapes)
+│   └── crossref.py             # Détection cross-source → MicroSignal
+├── processing/
+│   ├── nlp.py                  # NER spaCy français
+│   ├── geocoder.py             # Résolution commune/EPCI/département
+│   ├── ocr.py                  # OCR via GLM-OCR / Ollama
+│   └── contextualizer.py       # Descriptions LLM des anomalies
+├── storage/
+│   ├── models.py               # Signal, Anomaly (SQLAlchemy)
+│   └── repository.py           # SignalRepository (async)
+├── detection/
+│   └── anomaly.py              # Détection statistique (z-score, IQR, PyOD)
+├── quant/
+│   ├── factors.py              # Facteurs alpha (Phase 2)
+│   ├── scoring.py              # Score composite (Phase 2)
+│   ├── temporal.py             # Analyse temporelle (Phase 3)
+│   ├── trends.py               # Détection de tendances (Phase 3)
+│   ├── factor_mining.py        # Factor mining LLM (Phase 4)
+│   ├── ml_detection.py         # ML non supervisé (Phase 4)
+│   ├── population.py           # Population INSEE
+│   └── qlib/                   # Adaptation QLib (handler, expressions, ops, ...)
+├── epci/
+│   ├── referentiel.py          # Mapping commune → EPCI
+│   ├── enrichment.py           # Enrichissement code_epci
+│   └── scoring.py              # Scoring au niveau EPCI
+├── scheduler/
+│   └── jobs.py                 # CollectorScheduler (APScheduler)
+└── config/
+    └── sources.yaml            # Déclaration des sources et seuils de détection
+```
+
+## Configuration
+
+Variables d'environnement :
+
+| Variable | Description |
+|----------|-------------|
+| `COLLECTOR_DATABASE_URL` | URL PostgreSQL des signaux (défaut: `postgresql+asyncpg://localhost:5432/tawiza`) |
+| `INSEE_CLIENT_ID` / `INSEE_CLIENT_SECRET` | Identifiants API INSEE (SIRENE) |
+| `FRANCE_TRAVAIL_CLIENT_ID` / `FRANCE_TRAVAIL_CLIENT_SECRET` | Identifiants API France Travail |
+
+Le scheduler lit aussi les identifiants depuis un fichier `.env` à la racine du package. Le fichier `config/sources.yaml` déclare les sources (type, schedule cron, rate limit, description), les départements à surveiller et les seuils de détection (`zscore_threshold`, `min_cross_sources`, `lookback_weeks`).
+
+## État actuel
+
+- Le pipeline de bout en bout (collecte → stockage → détection → scoring) est fonctionnel
+- 13 collecteurs API + 2 crawlers implémentés, tous héritant de `BaseCollector`
+- La détection cross-source et le scoring quantitatif (Phases 2 à 4) sont opérationnels
+- Le watchdog réseau relance automatiquement la collecte au retour de connectivité
+- Les collecteurs lourds (Common Crawl, presse, Google Trends) sont lazy-loaded
+- La granularité EPCI est intégrée mais l'enrichissement se lance manuellement
+
+## Limitations connues
+
+- La collecte porte sur un sous-ensemble fixe de départements (pas toute la France)
+- Le crawler LeBonCoin dépend d'un routage anti-bot externe et reste fragile
+- Le factor mining et la contextualisation des anomalies dépendent de la disponibilité d'Ollama
+- L'OCR (GLM-OCR) et certaines dépendances lourdes sont optionnels
+- Les scores quantitatifs nécessitent un historique suffisant pour converger (cold start)
+- Le scheduler perd ses statistiques de session au redémarrage (pas de persistance)

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -1,0 +1,181 @@
+# Core
+
+Module de fondation transverse de Tawiza. Regroupe la configuration, les constantes, la hiérarchie d'exceptions, le logging, les utilitaires de sécurité, la gestion d'état système et la télémétrie. Tous les autres modules s'appuient sur `src/core/` pour leurs réglages, leur journalisation et leurs erreurs typées.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                         src/core/                             │
+│                                                               │
+│  ┌──────────────┐   ┌──────────────┐   ┌──────────────────┐   │
+│  │  config.py   │   │ constants.py │   │  exceptions.py   │   │
+│  │ Settings     │   │ Valeurs      │   │ Hiérarchie       │   │
+│  │ pydantic     │   │ figées       │   │ TawizaException  │   │
+│  └──────────────┘   └──────────────┘   └──────────────────┘   │
+│                                                               │
+│  ┌──────────────┐   ┌──────────────┐   ┌──────────────────┐   │
+│  │ logging_     │   │ security.py  │   │ system_state.py  │   │
+│  │ config.py    │   │ Secrets ·    │   │ Singleton thread-│   │
+│  │ loguru       │   │ sanitization │   │ safe + snapshots │   │
+│  └──────────────┘   └──────────────┘   └──────────────────┘   │
+│                                                               │
+│  ┌──────────────────────────────────────────────────────┐    │
+│  │                    telemetry.py                       │    │
+│  │      Télémétrie anonyme opt-out (PostHog)             │    │
+│  └──────────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Composants
+
+### Configuration (`config.py`)
+
+Gestion centralisée des réglages via **pydantic-settings**. La classe `Settings` agrège des sous-réglages, chacun chargé depuis l'environnement (préfixe dédié) et le fichier `.env` :
+
+| Sous-réglage | Préfixe env | Contenu |
+|--------------|-------------|---------|
+| `DatabaseSettings` | `DATABASE_` | URL PostgreSQL (asyncpg), pool, overflow, echo SQL |
+| `OllamaSettings` | `OLLAMA_` | URL API, modèle, modèle d'embedding, température, timeout |
+| `VectorDBSettings` | `VECTORDB_` | activation, dimension d'embedding, taille/overlap de chunk |
+| `RedisSettings` | `REDIS_` | URL de connexion Redis |
+| `APISettings` | `API_` | host, port, préfixe, origines CORS |
+
+Un singleton `settings` est instancié à l'import. Le modèle par défaut Ollama est `qwen2.5:7b`, l'embedding `nomic-embed-text`.
+
+### Constantes (`constants.py`)
+
+Centralise les nombres magiques, versions et valeurs par défaut sous forme de `Final` typés, pour éviter la duplication. Regroupements principaux :
+
+- **Version** : `APP_VERSION` (`2.0.3`), `APP_NAME` (`Tawiza-V2`), `MIN_PYTHON_VERSION` (`3.10`)
+- **Timeouts** : commandes (`SHORT`/`MEDIUM`/`LONG`/`EXTENDED`/`MAX`), réseau HTTP, retries
+- **Répertoires** : `DIRS_TO_CREATE`, `LOG_DIR`, `DATA_DIR`, `MODELS_DIR`, etc.
+- **Seuils ressources** : CPU/mémoire/disque (warning + critical)
+- **Scores de santé** : excellent/good/medium + pénalités
+- **Ports par défaut** : API (8000), Prometheus (9090), Grafana (3000), MLflow (5000), Ollama (11434), etc.
+- **Base de données / Redis / Ollama** : tailles de pool et TTL de cache
+- **Entraînement** : batch size, learning rate, époques, rang/alpha LoRA
+- **Vector DB** : dimension, taille de chunk, seuil de distance
+- **GPU** : `ROCM_PATH_DEFAULT` (`/opt/rocm`), `GPU_PLATFORM_AMD`
+- **Icônes et indicateurs** : pictogrammes de statut
+
+### Exceptions (`exceptions.py`)
+
+Hiérarchie d'exceptions typées qui remplace les `except` nus et porte un contexte structuré. Toutes héritent de `TawizaException`, qui transporte un `message` et un dictionnaire `details`.
+
+```
+TawizaException
+├── TawizaConfigurationError
+│   ├── ConfigurationNotFoundError
+│   ├── ConfigurationCorruptedError
+│   └── InvalidConfigurationError
+├── TawizaResourceError
+│   └── ResourceExhaustedError
+│       ├── MemoryExhaustedError
+│       └── DiskSpaceExhaustedError
+├── TawizaValidationError
+├── SystemNotInitializedError / SystemAlreadyInitializedError / SystemInitializationError
+├── SystemRequirementError
+│   ├── PythonVersionError
+│   ├── DockerNotAvailableError
+│   └── GPUNotAvailableError
+│       └── ROCmNotInstalledError
+├── AgentError (AgentNotAvailable · AgentExecution · AgentTimeout)
+├── TaskError (NotFound · NotCompleted · NotCancellable · AlreadyRunning)
+├── SecurityError (InsecureConfiguration · PathTraversal · CommandInjection)
+├── DebugError (DebuggerNotStarted · DebuggerAlreadyRunning)
+├── ExternalServiceError (ServiceUnavailable · ServiceTimeout · OllamaService · MLflowService)
+└── ModelError (ModelNotFound · ModelLoad)
+```
+
+Deux helpers : `require_system_initialized()` et `require_debugger_started()` lèvent l'exception adéquate si la précondition n'est pas remplie.
+
+### Logging (`logging_config.py`)
+
+Configuration unifiée de la journalisation via **loguru**. Tous les modules importent `logger` depuis ce fichier plutôt que la lib standard.
+
+- **Corrélation de requête** : `ContextVar` `request_id` et `user_id`, avec getters/setters dédiés
+- **`InterceptHandler`** : redirige le logging stdlib vers loguru pour capturer les libs tierces
+- **`format_record()`** : format coloré `TIME | LEVEL | MODULE:LINE [req=… user=…] - MESSAGE`
+- **`configure_logging()`** : niveau, sortie JSON optionnelle, fichier avec rotation (`10 MB`) et rétention (`1 week`) + compression `gz`
+- Les loggers bruyants (uvicorn, fastapi, httpx, sqlalchemy.engine, playwright) sont mis à `WARNING`
+
+Le logging est configuré au niveau `INFO` dès l'import, reconfigurable via `configure_logging()`.
+
+### Sécurité (`security.py`)
+
+Utilitaires pour prévenir les vulnérabilités courantes.
+
+| Fonction / Classe | Rôle |
+|-------------------|------|
+| `SecretManager` | Récupère/génère/valide la clé secrète. Exige `SECRET_KEY` en production, génère une clé temporaire en développement |
+| `sanitize_path()` | Empêche le path traversal, restreint à un répertoire de base |
+| `validate_filename()` | Valide un nom de fichier (caractères sûrs, pas de fichier caché, longueur max) |
+| `sanitize_command_arg()` | Détecte les caractères dangereux et la substitution de commande |
+| `validate_subprocess_command()` | Interdit l'exécution shell (`sh`, `bash`, …) dans un subprocess |
+| `validate_port()` | Vérifie qu'un port est entre 1 et 65535 |
+| `validate_timeout()` | Valide une durée (non négative, alerte au-delà d'une heure) |
+| `sanitize_log_message()` | Empêche l'injection de logs (suppression des sauts de ligne) |
+| `get_security_headers()` | Renvoie les en-têtes HTTP de sécurité recommandés (CSP, HSTS, X-Frame-Options, …) |
+
+### État système (`system_state.py`)
+
+Singleton thread-safe qui remplace les variables globales mutables par un accès contrôlé.
+
+- **`InitializationConfig`** : dataclass figée (GPU, monitoring, tâches concurrentes, auto-scale, retries)
+- **`SystemState`** : snapshot immuable (composants, config, métadonnées, compteurs de tâches). Propriétés `is_initialized`, `has_gpu`, `has_monitoring` ; méthode `with_updates()` pour produire un nouvel état sans muter l'ancien
+- **`SystemStateManager`** : singleton à double-checked locking (`Lock` pour la création, `RLock` réentrant pour l'accès). Conserve un historique des 10 derniers états. Méthodes `update_state()`, `clear_state()`, `is_initialized()`, `get_state_or_raise()`, `increment_tasks()`, `get_history()`, `get_metrics()`
+
+Fonctions de commodité au niveau module : `get_system_state_manager()`, `get_current_state()`, `is_system_initialized()`, `require_initialized()`.
+
+### Télémétrie (`telemetry.py`)
+
+Télémétrie anonyme **opt-out** envoyée vers PostHog (clé en écriture seule, dashboard de l'équipe Tawiza).
+
+- Désactivable via `TELEMETRY_ENABLED=false`
+- Identifiant anonyme stable par installation (`~/.tawiza/.telemetry_id`, hash SHA-256, aucune PII)
+- Client PostHog lazy-init, échec silencieux  -  la télémétrie ne doit jamais casser l'application
+- Événements : `capture()`, `capture_feature()`, `capture_agent()`, `capture_datasource()`, `capture_startup()`, plus `shutdown()` pour vider les événements en attente
+- Chaque événement enrichi de propriétés de base : version, version Python, OS, architecture
+
+## Fichiers clés
+
+```
+src/core/
+├── config.py            # Settings pydantic (DB, Ollama, VectorDB, Redis, API)
+├── constants.py         # Constantes Final (versions, timeouts, ports, seuils)
+├── exceptions.py        # Hiérarchie TawizaException + helpers
+├── logging_config.py    # Logging loguru + corrélation request/user
+├── security.py          # Secrets, sanitization, validation, headers
+├── system_state.py      # Singleton thread-safe + snapshots immuables
+└── telemetry.py         # Télémétrie anonyme PostHog (opt-out)
+```
+
+## Variables d'environnement
+
+| Variable | Description | Défaut |
+|----------|-------------|--------|
+| `DATABASE_URL` | URL PostgreSQL (asyncpg) | `postgresql+asyncpg://tawiza:changeme@localhost:5432/tawiza` |
+| `OLLAMA_BASE_URL` | URL API Ollama | `http://localhost:11434` |
+| `REDIS_URL` | URL Redis | `redis://localhost:6379/0` |
+| `VECTORDB_ENABLED` | Activer la base vectorielle | `true` |
+| `API_PORT` | Port de l'API | `8000` |
+| `SECRET_KEY` | Clé secrète (obligatoire en production, min. 32 caractères) |  -  |
+| `APP_ENV` | Environnement (`development` / `production`) | `development` |
+| `TELEMETRY_ENABLED` | Activer la télémétrie anonyme | `true` |
+
+Les sous-réglages pydantic acceptent aussi la notation à double underscore (ex. `OLLAMA__BASE_URL`).
+
+## État actuel
+
+- La configuration pydantic, les constantes, la hiérarchie d'exceptions et le logging loguru sont stables et utilisés transversalement
+- Les utilitaires de sécurité (sanitization, validation, headers) sont en place
+- Le `SystemStateManager` thread-safe remplace les anciens globaux mutables
+- La télémétrie anonyme est opt-out et conçue pour échouer silencieusement
+
+## Limitations connues
+
+- La clé secrète générée en développement est éphémère (régénérée à chaque démarrage si `SECRET_KEY` n'est pas défini)
+- L'historique d'état est limité aux 10 derniers snapshots et n'est pas persisté
+- `validate_subprocess_command()` interdit le shell mais ne valide pas l'existence ni les droits du binaire appelé
+- La télémétrie embarque une clé PostHog publique en écriture seule directement dans le code

--- a/docs/modules/mcp.md
+++ b/docs/modules/mcp.md
@@ -1,0 +1,195 @@
+# Serveur MCP
+
+Serveur **Model Context Protocol** de Tawiza. Expose les outils d'analyse de marchés territoriaux français à des clients MCP externes (Cherry Studio et autres). Construit sur `FastMCP` et organisé en outils, ressources et notifications de progression.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                      FastMCP "Tawiza"                          │
+│                                                                │
+│   Transport: stdio (défaut)  ou  SSE (HTTP Server-Sent Events) │
+│                                                                │
+│  ┌────────────────────────┐   ┌──────────────────────────┐    │
+│  │        Tools           │   │        Resources         │    │
+│  │  (13 modules register) │   │  tawiza://sources        │    │
+│  │                        │   │  tawiza://agents         │    │
+│  │  high_level · granular │   │  tawiza://workforce      │    │
+│  │  browser · dashboard   │   │  tawiza://alerts         │    │
+│  │  web_search · workforce│   │  tawiza://veille         │    │
+│  │  veille · comparison   │   │  tawiza://dashboard/*     │    │
+│  │  prospection           │   └──────────────────────────┘    │
+│  │  simulation            │                                    │
+│  │  business_plan         │   ┌──────────────────────────┐    │
+│  │  benchmark             │   │      Notifications       │    │
+│  └────────────────────────┘   │   ProgressNotifier       │    │
+│                                │   (step/source/agent/    │    │
+│                                │    browser/geocode)      │    │
+│                                └──────────────────────────┘    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Transports
+
+Le serveur se lance via `python -m src.infrastructure.mcp` :
+
+| Transport | Commande | Usage |
+|-----------|----------|-------|
+| **stdio** (défaut) | `python -m src.infrastructure.mcp` | Clients MCP locaux |
+| **SSE** (HTTP) | `python -m src.infrastructure.mcp --sse --port 8080 --host 0.0.0.0` | Accès réseau distant (Cherry Studio) |
+
+En mode SSE, un serveur de fichiers statiques est démarré en parallèle sur `port + 1` pour exposer le répertoire `outputs/` (cartes HTML, rapports). L'endpoint SSE est `http://<host>:<port>/sse`.
+
+## Outils MCP
+
+Les outils sont enregistrés par 13 fonctions `register_*_tools(mcp)` appelées dans `server.py`.
+
+### `high_level.py`  -  Outils de haut niveau
+Outils orchestrant le pipeline complet :
+- `tawiza_analyze` : Analyse complète d'un marché territorial
+- `tawiza_search` : Recherche multi-sources dans les bases françaises
+- `tawiza_validate` : Validation par débat multi-agents LLM
+- `tawiza_map` : Génération de carte interactive
+- `tawiza_chat` : Assistant conversationnel
+
+### `granular.py`  -  Outils granulaires
+Accès direct à chaque source/capacité :
+- `sirene_search`, `bodacc_search`, `boamp_search` : Recherche par base
+- `geo_locate`, `geo_batch_locate`, `geo_generate_map` : Géocodage (BAN) et cartographie Folium
+- `debate_run` : Lancement d'un débat multi-agents
+- `gdelt_search` : Recherche d'actualités GDELT
+- `subventions_search` : Subventions publiques (data.gouv.fr)
+
+### `browser.py`  -  Pilotage navigateur (PiP)
+Streaming Picture-in-Picture et automatisation :
+- `browser_start_stream`, `browser_stop_stream`, `browser_screenshot`
+- `browser_navigate`, `browser_click`, `browser_extract`, `browser_scrape_page`
+
+### `dashboard.py`  -  Dashboard et watchlist
+Gestion des alertes et de la surveillance :
+- `dashboard_mark_read`, `dashboard_get_alert`, `dashboard_get_alerts`
+- `watchlist_add`, `watchlist_remove`, `watchlist_list`
+- `watcher_force_poll`, `tawiza_dashboard_status`
+
+### `web_search.py`  -  Recherche web DuckDuckGo
+Recherche gratuite sans clé API :
+- `web_search`, `web_search_news`, `web_search_images`, `web_search_maps`
+
+### `workforce.py`  -  Workforce CAMEL AI
+Analyse de marché via 4 agents CAMEL coordonnés :
+- `tawiza_workforce_analyze` : Analyse complète (rapport + carte + CSV + metadata)
+- `tawiza_workforce_status` : Statut du système Workforce
+
+### `veille.py`  -  Veille automatisée
+Monitoring continu avec filtrage LLM :
+- `tawiza_veille_scan`, `tawiza_veille_digest`
+- `tawiza_veille_configure`, `tawiza_veille_alert_detail`
+
+### `comparison.py`  -  Comparaison multi-territoires
+- `tawiza_compare_markets` : Comparaison d'un marché sur plusieurs territoires en parallèle
+- `tawiza_territory_benchmark` : Benchmark d'un territoire sur plusieurs secteurs
+
+### `prospection.py`  -  Prospection automatisée
+Génération et enrichissement de leads :
+- `tawiza_prospect`, `tawiza_prospect_export`
+- `tawiza_generate_message`, `tawiza_lead_score`, `tawiza_financial_health`
+
+### `simulation.py`  -  Simulation de scénarios économiques
+- `tawiza_simulate` : Simulation d'impact d'un scénario sur un territoire
+- `tawiza_scenarios_list`, `tawiza_impact_analysis`
+
+### `business_plan.py`  -  Génération de business plans
+- `tawiza_generate_bp`, `tawiza_bp_templates`
+- `tawiza_bp_section`, `tawiza_bp_from_analysis`
+
+### `benchmark.py`  -  Benchmark des outils
+- `tawiza_benchmark_run`, `tawiza_benchmark_list`
+- `tawiza_benchmark_tool`, `tawiza_benchmark_compare`
+
+## Ressources MCP
+
+Les ressources exposent des informations sur le serveur (statiques et dynamiques).
+
+### Ressources statiques (`server.py`)
+
+| URI | Description |
+|-----|-------------|
+| `tawiza://sources` | Liste des sources de données (SIRENE, BODACC, BOAMP, BAN, GDELT, subventions) |
+| `tawiza://agents` | Description du pipeline de débat (6 agents : Chercheur, SourceRanker, Critique, FactChecker, Vérificateur, Synthèse) |
+| `tawiza://workforce` | Description du Workforce CAMEL AI (4 agents) |
+| `tawiza://alerts` | Alertes de veille en temps réel (lecture `DashboardDB`) |
+| `tawiza://veille` | Documentation de la veille automatisée |
+
+### Ressources dynamiques (`resources/dashboard.py`)
+
+Enregistrées via `register_dashboard_resources(mcp)`, elles interrogent `DashboardDB` et renvoient du JSON :
+
+| URI | Description |
+|-----|-------------|
+| `tawiza://dashboard/status` | État système (sources, watcher, base, statut Ollama) |
+| `tawiza://dashboard/alerts` | Alertes non lues par source |
+| `tawiza://dashboard/history` | Historique des analyses récentes |
+| `tawiza://dashboard/stats` | Statistiques d'utilisation sur 7 jours |
+
+## Notifications de progression
+
+Le module `notifications/progress.py` fournit le `ProgressNotifier`, qui relaie les mises à jour de progression vers le client MCP pendant les opérations longues. Il enveloppe `ctx.report_progress` et accepte des callbacks additionnels.
+
+Types d'événements (`ProgressType`) :
+
+| Type | Usage |
+|------|-------|
+| `STEP` | Progression d'une étape principale |
+| `SOURCE` | Requête vers une source de données |
+| `AGENT` | Activité d'un agent de débat |
+| `BROWSER` | Navigation navigateur |
+| `GEOCODE` | Opération de géocodage |
+
+Le `StepContext` (context manager `async`) permet de suivre une étape avec compteur (`update()`, `increment()`).
+
+## Fichiers clés
+
+```
+src/infrastructure/mcp/
+├── server.py                   # Serveur FastMCP : args, transports, ressources statiques
+├── __main__.py                 # Point d'entrée (python -m src.infrastructure.mcp)
+├── __init__.py                 # Exporte mcp, run_server
+├── tools/
+│   ├── high_level.py           # tawiza_analyze, search, validate, map, chat
+│   ├── granular.py             # SIRENE/BODACC/BOAMP, geo, debate, GDELT, subventions
+│   ├── browser.py              # Pilotage navigateur PiP
+│   ├── dashboard.py            # Alertes et watchlist
+│   ├── web_search.py           # Recherche DuckDuckGo
+│   ├── workforce.py            # Workforce CAMEL AI
+│   ├── veille.py               # Veille automatisée
+│   ├── comparison.py           # Comparaison multi-territoires
+│   ├── prospection.py          # Prospection et leads
+│   ├── simulation.py           # Simulation de scénarios
+│   ├── business_plan.py        # Génération de business plans
+│   └── benchmark.py            # Benchmark des outils
+├── resources/
+│   └── dashboard.py            # Ressources dynamiques tawiza://dashboard/*
+├── notifications/
+│   └── progress.py             # ProgressNotifier, StepContext
+└── chat/                       # Package assistant chat (placeholder)
+```
+
+## Configuration
+
+| Argument | Description | Défaut |
+|----------|-------------|--------|
+| `--sse` | Active le transport SSE (HTTP) au lieu de stdio | `false` (stdio) |
+| `--port` | Port du serveur SSE | `8080` |
+| `--host` | Hôte du serveur SSE | `0.0.0.0` |
+
+En mode SSE, le serveur de fichiers statiques (répertoire `outputs/`) écoute sur `port + 1`.
+
+Les ressources du dashboard vérifient le statut Ollama via `http://localhost:11434/api/tags`.
+
+## État actuel
+
+- Le serveur expose 13 modules d'outils et un ensemble de ressources statiques + dynamiques
+- Les transports stdio et SSE sont opérationnels, avec serveur de fichiers statiques en SSE
+- Les ressources du dashboard sont alimentées par `DashboardDB` et `WatcherDaemon`
+- Le système de notifications de progression est intégré aux outils longs
+- Le package `chat/` est un placeholder (uniquement `__init__.py`)

--- a/docs/modules/scripts.md
+++ b/docs/modules/scripts.md
@@ -1,0 +1,184 @@
+# Scripts standalone
+
+Scripts exécutables en ligne de commande qui composent le pipeline batch de Tawiza : collecte des sources publiques, détection d'anomalies, embeddings sémantiques, scoring territorial, surveillance continue et génération de données d'entraînement. Ils s'appuient sur la table `signals` unifiée et alimentent les tables exposées par l'API.
+
+## Architecture du pipeline
+
+```
+┌──────────────────┐
+│  collect_all_v2  │  Collecte multi-sources → table `signals`
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│ detect_anomalies │     │   embed_signals  │     │ scoring_composite│
+│      _v2         │     │  (pgvector)      │     │   (lib + CLI)    │
+│ anomaly_detection│     │ signal_embeddings│     │territorial_snap. │
+└──────────────────┘     └──────────────────┘     └──────────────────┘
+         ▲
+         │
+┌──────────────────┐     ┌──────────────────┐
+│    scheduler     │     │     watcher      │
+│  (APScheduler)   │     │ (daemon Z-score) │
+│ orchestre tout   │     │  watcher_alerts  │
+└──────────────────┘     └──────────────────┘
+
+┌──────────────────────┐
+│ generate_training_data│  Hors pipeline → JSONL pour fine-tuning TAJINE
+└──────────────────────┘
+```
+
+`scheduler.py` est le chef d'orchestre : il déclenche `collect_all_v2` et la détection selon des plages horaires. Les autres scripts peuvent aussi être lancés manuellement.
+
+## Scripts de collecte
+
+### `collect_all_v2.py`  -  Collecteur unifié
+
+Collecte huit sources publiques et insère tout dans la table `signals` :
+BODACC (liquidations, créations, modifications), France Travail (offres d'emploi), SIRENE (créations via data.gouv.fr), INSEE (chômage BDM, population geo.api), OFGL (finances locales), DVF (transactions immobilières), Banque de France (défaillances), Presse locale (RSS).
+
+| Élément | Valeur |
+|---------|--------|
+| Commande | `python3 src/scripts/collect_all_v2.py [--depts 75 93 ...] [--sources bodacc sirene ...] [--days 30] [--all]` |
+| Défaut | 20 départements stratégiques, lookback 30 jours, toutes les sources |
+| Sortie | Insertion dans la table `signals` |
+| Cron suggéré | Géré par le scheduler (voir `scheduler.py`) |
+
+Sans `--depts` ni `--all`, le script cible un mix de 20 départements (IDF, grandes métropoles). `--all` couvre les 101 départements (métropole + Corse + DROM).
+
+## Scripts d'analyse
+
+### `detect_anomalies_v2.py`  -  Détection d'anomalies
+
+Détection multivariée qui remplace le simple Z-score :
+- **Isolation Forest** : combinaisons inhabituelles de métriques par département
+- **DBSCAN** : regroupement des départements par profil économique, identification des outliers
+- **Score de convergence v2** : pondéré par temporalité, causalité et fiabilité de la source (poids `SOURCE_WEIGHTS`, règles `CAUSAL_RULES`)
+
+| Élément | Valeur |
+|---------|--------|
+| Commande | `python3 src/scripts/detect_anomalies_v2.py` |
+| Sortie | Table `anomaly_detection_v2` (upsert sur `department, detection_date`) + log du top 10 risque et des clusters |
+| Cron suggéré | Géré par le scheduler (jobs de détection à 7h et 19h) |
+
+### `embed_signals.py`  -  Embeddings sémantiques
+
+Génère des embeddings 768 dimensions via `nomic-embed-text` (Ollama) pour la recherche sémantique pgvector. Traite les signaux par lots et saute ceux déjà encodés.
+
+| Élément | Valeur |
+|---------|--------|
+| Commande | `python3 src/scripts/embed_signals.py [--limit 50000]` |
+| Recherche | `python3 src/scripts/embed_signals.py --search "ma requête"` (affiche les signaux similaires) |
+| Sortie | Table `signal_embeddings` (signal_id, embedding, text_content) |
+| Cron suggéré | Après chaque collecte importante (manuel ou ajout au scheduler) |
+
+### `scoring_composite.py`  -  Scoring composite (librairie + CLI)
+
+Calcule un score territorial composite à partir de 6 alpha factors normalisés par population :
+
+| Facteur | Dimension |
+|---------|-----------|
+| α1 | Santé des entreprises (créations vs liquidations, BODACC + SIRENE) |
+| α2 | Tension emploi (offres FT, ratio CDI, URSSAF AE) |
+| α3 | Dynamisme immobilier (prix DVF, volume transactions) |
+| α4 | Santé financière (OFGL dépenses/recettes, dette/hab) |
+| α5 | Déclin ratio (liquidations + radiations vs créations) |
+| α6 | Sentiment presse + Google Trends |
+
+Score composite = Σ(αi × wi) / Σ(wi), normalisé 0-100.
+
+Contrairement aux autres scripts, ce module est avant tout une **librairie** : sa fonction `get_department_scores()` est importée par l'API (`src/interfaces/api/v1/signals.py`). Il reste exécutable en CLI pour un calcul ponctuel.
+
+| Élément | Valeur |
+|---------|--------|
+| Commande | `python3 src/scripts/scoring_composite.py` |
+| Import API | `from src.scripts.scoring_composite import get_department_scores` |
+| Sortie | Table `territorial_snapshots` (upsert) + classement loggé (top 20 / bottom 10) |
+| Cron suggéré | Recalcul périodique après mise à jour des signaux |
+
+## Scripts d'orchestration et de surveillance
+
+### `scheduler.py`  -  Ordonnanceur APScheduler
+
+Planifie automatiquement les collectes et détections via `AsyncIOScheduler` (timezone `Europe/Paris`). C'est le service à lancer pour faire tourner le pipeline en continu.
+
+| Job | Trigger | Sources / action |
+|-----|---------|------------------|
+| `collect_frequent` | 0h, 6h, 12h, 18h | BODACC + France Travail + Presse (lookback 7j) |
+| `collect_daily` | 6h15 | SIRENE + INSEE + OFGL (lookback 30j) |
+| `collect_weekly` | dimanche 3h | DVF (lookback 90j) |
+| `detect_microsignals` | 7h et 19h | Détection micro-signaux + temporelle + alertes Telegram |
+
+| Élément | Valeur |
+|---------|--------|
+| Commande | `python3 src/scripts/scheduler.py` (tourne en continu) |
+| Sortie | Déclenche les autres scripts, alimente les tables qu'ils visent |
+
+Le job de détection importe `detect_microsignals_v2`, `detect_temporal` et `alert_telegram` de façon optionnelle (skip silencieux si le module est absent).
+
+### `watcher.py`  -  Surveillance continue
+
+Daemon qui compare toutes les N minutes les dernières valeurs aux moyennes historiques et détecte les écarts significatifs (Z-score). Les métriques surveillées sont groupées par priorité (high / medium / low).
+
+| Élément | Valeur |
+|---------|--------|
+| Commande (daemon) | `python3 src/scripts/watcher.py [--interval 30] [--threshold 2.0]` |
+| Commande (one-shot) | `python3 src/scripts/watcher.py --once` |
+| Sortie | Table `watcher_alerts` (exposée via API) |
+| Cron suggéré | Aucun (daemon long-running, intervalle interne 30 min) |
+
+Paramètres internes : `WATCH_INTERVAL_MINUTES=30`, `LOOKBACK_DAYS=90`, `Z_THRESHOLD=2.0`, `MIN_DATA_POINTS=5`.
+
+## Script de génération de données
+
+### `generate_training_data.py`  -  Données de fine-tuning TAJINE
+
+Génère des paires question/réponse synthétiques sur l'intelligence territoriale à partir des signaux réels en base. Sortie au format JSONL compatible Ollama (SFT). Pour chaque département ayant plus de 50 signaux, récupère un contexte, construit une question depuis des templates, puis génère la réponse via le LLM (`qwen3.5:27b`).
+
+| Élément | Valeur |
+|---------|--------|
+| Commande | `python3 src/scripts/generate_training_data.py [--count 200] [--output training_data.jsonl] [--dry-run]` |
+| `--dry-run` | Génère seulement les questions, sans appeler le LLM |
+| Sortie | Fichier JSONL (rôles system/user/assistant + metadata) |
+| Cron suggéré | Aucun (lancement manuel avant un fine-tuning) |
+
+## Variables d'environnement
+
+Les scripts chargent le `.env` à la racine du projet (`load_dotenv`).
+
+| Variable | Description | Défaut | Scripts |
+|----------|-------------|--------|---------|
+| `DATABASE_URL` | DSN PostgreSQL | `postgresql://localhost:5432/tawiza` | `detect_anomalies_v2`, `embed_signals`, `watcher`, `collect_all_v2` |
+| `COLLECTOR_DATABASE_URL` | DSN PostgreSQL (collecteur) | `postgresql+asyncpg://localhost:5432/tawiza` | `generate_training_data`, `scoring_composite` |
+| `OLLAMA_URL` | URL du serveur Ollama | `http://localhost:11434` | `generate_training_data`, `embed_signals` |
+| `FRANCE_TRAVAIL_CLIENT_ID` / `FRANCE_TRAVAIL_CLIENT_SECRET` | Identifiants API France Travail | - | `collect_all_v2` |
+| `INSEE_CLIENT_ID` / `INSEE_CLIENT_SECRET` | Identifiants API INSEE | - | `collect_all_v2` |
+
+Le suffixe `+asyncpg` est retiré automatiquement avant connexion `asyncpg`.
+
+## Fichiers clés
+
+```
+src/scripts/
+├── collect_all_v2.py          # Collecteur unifié 8 sources → signals
+├── detect_anomalies_v2.py     # Isolation Forest + DBSCAN → anomaly_detection_v2
+├── embed_signals.py           # Embeddings pgvector → signal_embeddings
+├── scoring_composite.py       # 6 alpha factors (lib API) → territorial_snapshots
+├── scheduler.py               # APScheduler, orchestre collectes + détection
+├── watcher.py                 # Daemon Z-score → watcher_alerts
+└── generate_training_data.py  # QA pairs synthétiques → JSONL fine-tuning
+```
+
+## État actuel
+
+- `collect_all_v2`, `detect_anomalies_v2`, `scoring_composite` et `watcher` sont fonctionnels et alimentent leurs tables respectives
+- `scheduler` orchestre l'ensemble du pipeline batch en continu
+- `embed_signals` dépend d'Ollama (`nomic-embed-text`) pour la recherche sémantique pgvector
+- `generate_training_data` produit des données SFT mais le fine-tuning n'est pas activé en production
+
+## Limitations connues
+
+- Le scheduler appelle `detect_microsignals_v2`, `detect_temporal` et `alert_telegram` en import optionnel : si un module manque, le job est ignoré silencieusement (warning)
+- Le watcher tourne avec un état en mémoire : pas de reprise après redémarrage
+- Les scripts nécessitant Ollama (`embed_signals`, `generate_training_data`) échouent si le serveur LLM est indisponible
+- Les collectes France Travail et INSEE requièrent des identifiants API valides dans le `.env`


### PR DESCRIPTION
## Summary

Documents six previously-undocumented `src/` modules, matching the format of the
existing `docs/modules/` deep-dives, and links them from the README index (EN + FR).

| Module | Doc |
|--------|-----|
| `src/core/` | `docs/modules/core.md` |
| `src/application/` | `docs/modules/application.md` |
| `src/interfaces/api/` | `docs/modules/api.md` |
| `src/infrastructure/mcp/` | `docs/modules/mcp.md` |
| `src/collector/` | `docs/modules/collector.md` |
| `src/scripts/` | `docs/modules/scripts.md` |

All content is derived from reading the real code (role, ASCII architecture
diagram, key files, env var names, current state). No source code changed.

Closes #155, #156, #158, #159, #165, #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Expanded navigation links in README files to provide easier access to comprehensive module documentation
* Added detailed documentation for API, Application layer, Collector, Core, MCP, and Scripts modules to help users understand system architecture and capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->